### PR TITLE
Wire ISteamRemoteStorage: cloud saves were invisible to the game

### DIFF
--- a/src/shim/shim_abi.h
+++ b/src/shim/shim_abi.h
@@ -158,6 +158,52 @@ enum shim_call
     C_Overlay_SetNotificationPosition,
     C_Overlay_SetNotificationInset,
 
+    /* ISteamRemoteStorage (slots 0-23 of VERSION014/016) — the Steam Cloud file
+     * surface (#43). Appended after the overlay block so existing opcode indices
+     * are undisturbed.
+     *
+     * This is the interface a title with cloud saves reads its save THROUGH: the
+     * bytes on disk in userdata/<id>/<appid>/remote are Steam's business, not the
+     * game's. Space Marine (3169520) never opens that directory — it asks
+     * FileExists("smsave0.dsav"). Left stubbed, that is `false`, and the title
+     * offers only "New Campaign" with a complete save sitting on disk. FileWrite
+     * being stubbed alongside it is why the same run cannot save either.
+     *
+     * Unlike ISteamFriends' overlay block, these need no `slot` field: no version
+     * of ISteamRemoteStorage declares a same-name overload (checked against
+     * vtables.json), so the dylib's Itanium order IS the MSVC order the PE side
+     * holds, and casting the handle to one fixed class dispatches correctly on
+     * every version. Slots 0-23 are also shape-identical from v001 through v016,
+     * which is what lets one wire_all per method reach them all.
+     *
+     * Slots 24-58 (UGC, workshop publishing, video, local-file-change batching)
+     * are deliberately absent: a different subsystem, unexercised by any title in
+     * hand, and each needs types the seam does not carry. */
+    C_RS_FileWrite,
+    C_RS_FileRead,
+    C_RS_FileWriteAsync,
+    C_RS_FileReadAsync,
+    C_RS_FileReadAsyncComplete,
+    C_RS_FileForget,
+    C_RS_FileDelete,
+    C_RS_FileShare,
+    C_RS_SetSyncPlatforms,
+    C_RS_FileWriteStreamOpen,
+    C_RS_FileWriteStreamWriteChunk,
+    C_RS_FileWriteStreamClose,
+    C_RS_FileWriteStreamCancel,
+    C_RS_FileExists,
+    C_RS_FilePersisted,
+    C_RS_GetFileSize,
+    C_RS_GetFileTimestamp,
+    C_RS_GetSyncPlatforms,
+    C_RS_GetFileCount,
+    C_RS_GetFileNameAndSize,
+    C_RS_GetQuota,
+    C_RS_IsCloudEnabledForAccount,
+    C_RS_IsCloudEnabledForApp,
+    C_RS_SetCloudEnabledForApp,
+
     C_COUNT
 };
 
@@ -249,3 +295,25 @@ struct sp_input_handles    { uint64_t handle; uint64_t out; int32_t ret; };
 /* ---- copy-out of native memory (#20) ---- */
 struct sp_copymem          { uint64_t src; uint64_t dst; int32_t len; };
 struct sp_copystr          { uint64_t src; uint64_t dst; int32_t cap; int32_t ret; };
+
+/* ---- ISteamRemoteStorage (slots 0-23) (#43) ----
+ * `data` and the out-params (`size_out`, `total`/`avail`) are addresses the GAME
+ * supplies, so on i386 they zero-extend and the native side reads and writes
+ * through them directly — same as GetUserDataFolder, and the copy-down path is
+ * not involved. The one exception is GetFileNameAndSize, whose const char*
+ * RETURN points into the dylib's heap above 4 GB; that one goes through
+ * native_str on the PE side like GetIPCountry does. */
+struct sp_rs_filedata      { uint64_t handle; uint64_t name; uint64_t data; int32_t count; int32_t ret; }; /* FileWrite -> bool, FileRead -> bytes read */
+struct sp_rs_writeasync    { uint64_t handle; uint64_t name; uint64_t data; uint64_t ret; int32_t count; }; /* FileWriteAsync -> SteamAPICall_t */
+struct sp_rs_readasync     { uint64_t handle; uint64_t name; uint64_t ret; int32_t offset; int32_t toread; }; /* FileReadAsync -> SteamAPICall_t */
+struct sp_rs_readasyncdone { uint64_t handle; uint64_t call; uint64_t data; int32_t toread; int32_t ret; }; /* FileReadAsyncComplete -> bool */
+struct sp_rs_name_i32      { uint64_t handle; uint64_t name; int32_t ret; };      /* FileForget/FileDelete/FileExists/FilePersisted -> bool; GetFileSize -> int32; GetSyncPlatforms -> ERemoteStoragePlatform */
+struct sp_rs_name_u64      { uint64_t handle; uint64_t name; uint64_t ret; };     /* FileShare -> SteamAPICall_t; FileWriteStreamOpen -> UGCFileWriteStreamHandle_t */
+struct sp_rs_name_i64      { uint64_t handle; uint64_t name; int64_t ret; };      /* GetFileTimestamp -> int64 */
+struct sp_rs_syncplat      { uint64_t handle; uint64_t name; int32_t platform; int32_t ret; }; /* SetSyncPlatforms -> bool */
+struct sp_rs_streamchunk   { uint64_t handle; uint64_t stream; uint64_t data; int32_t count; int32_t ret; }; /* FileWriteStreamWriteChunk -> bool */
+struct sp_rs_stream        { uint64_t handle; uint64_t stream; int32_t ret; };    /* FileWriteStreamClose/Cancel -> bool */
+struct sp_rs_noarg         { uint64_t handle; int32_t ret; };                     /* GetFileCount -> int32; IsCloudEnabledForAccount/App -> bool */
+struct sp_rs_namesize      { uint64_t handle; uint64_t size_out; uint64_t ret; int32_t index; }; /* GetFileNameAndSize -> const char* */
+struct sp_rs_quota         { uint64_t handle; uint64_t total; uint64_t avail; int32_t ret; };    /* GetQuota -> bool */
+struct sp_rs_setcloud      { uint64_t handle; int32_t enabled; };                 /* SetCloudEnabledForApp -> void */

--- a/src/shim/shim_pe.c
+++ b/src/shim/shim_pe.c
@@ -970,6 +970,105 @@ static void THISCALL iut_SetOverlayNotificationPosition(struct w_iface *s, int32
 static void THISCALL iut_SetOverlayNotificationInset(struct w_iface *s, int32_t x, int32_t y)
 { struct sp_overlay_inset p; (void)s; p.x = x; p.y = y; seam(C_Overlay_SetNotificationInset, &p); }
 
+/* ---- ISteamRemoteStorage thunks (slots 0-23) (#43) -----------------------
+ *
+ * The Steam Cloud file surface. A title with cloud saves does not read
+ * userdata/<id>/<appid>/remote itself — it asks these, and a stubbed FileExists
+ * makes a complete save invisible: Space Marine offers only "New Campaign" with
+ * 22 KB of campaign progress sitting on disk, and cannot write a new save
+ * either, because FileWrite is stubbed in the same breath.
+ *
+ * Buffers (`data`, `size_out`, the GetQuota out-params) are addresses the GAME
+ * owns, so they zero-extend on i386 and the native side reads and writes through
+ * them in place. GetFileNameAndSize is the one that cannot work that way: its
+ * const char* RETURN points into the dylib's heap above 4 GB, so it goes through
+ * native_str like GetIPCountry. */
+static uint8_t THISCALL irs_FileWrite(struct w_iface *s, const char *name, const void *data, int32_t count)
+{ struct sp_rs_filedata p; p.handle = s->handle; p.name = (uint64_t)(uintptr_t)name;
+  p.data = (uint64_t)(uintptr_t)data; p.count = count; p.ret = 0;
+  seam(C_RS_FileWrite, &p); return (uint8_t)p.ret; }
+static int32_t THISCALL irs_FileRead(struct w_iface *s, const char *name, void *data, int32_t count)
+{ struct sp_rs_filedata p; p.handle = s->handle; p.name = (uint64_t)(uintptr_t)name;
+  p.data = (uint64_t)(uintptr_t)data; p.count = count; p.ret = 0;
+  seam(C_RS_FileRead, &p); return p.ret; }
+static uint64_t THISCALL irs_FileWriteAsync(struct w_iface *s, const char *name, const void *data, uint32_t count)
+{ struct sp_rs_writeasync p; p.handle = s->handle; p.name = (uint64_t)(uintptr_t)name;
+  p.data = (uint64_t)(uintptr_t)data; p.count = (int32_t)count; p.ret = 0;
+  seam(C_RS_FileWriteAsync, &p); return p.ret; }
+static uint64_t THISCALL irs_FileReadAsync(struct w_iface *s, const char *name, uint32_t offset, uint32_t toread)
+{ struct sp_rs_readasync p; p.handle = s->handle; p.name = (uint64_t)(uintptr_t)name;
+  p.offset = (int32_t)offset; p.toread = (int32_t)toread; p.ret = 0;
+  seam(C_RS_FileReadAsync, &p); return p.ret; }
+static uint8_t THISCALL irs_FileReadAsyncComplete(struct w_iface *s, uint64_t call, void *data, uint32_t toread)
+{ struct sp_rs_readasyncdone p; p.handle = s->handle; p.call = call;
+  p.data = (uint64_t)(uintptr_t)data; p.toread = (int32_t)toread; p.ret = 0;
+  seam(C_RS_FileReadAsyncComplete, &p); return (uint8_t)p.ret; }
+static uint8_t THISCALL irs_FileForget(struct w_iface *s, const char *name)
+{ struct sp_rs_name_i32 p; p.handle = s->handle; p.name = (uint64_t)(uintptr_t)name; p.ret = 0;
+  seam(C_RS_FileForget, &p); return (uint8_t)p.ret; }
+static uint8_t THISCALL irs_FileDelete(struct w_iface *s, const char *name)
+{ struct sp_rs_name_i32 p; p.handle = s->handle; p.name = (uint64_t)(uintptr_t)name; p.ret = 0;
+  seam(C_RS_FileDelete, &p); return (uint8_t)p.ret; }
+static uint64_t THISCALL irs_FileShare(struct w_iface *s, const char *name)
+{ struct sp_rs_name_u64 p; p.handle = s->handle; p.name = (uint64_t)(uintptr_t)name; p.ret = 0;
+  seam(C_RS_FileShare, &p); return p.ret; }
+static uint8_t THISCALL irs_SetSyncPlatforms(struct w_iface *s, const char *name, int32_t platform)
+{ struct sp_rs_syncplat p; p.handle = s->handle; p.name = (uint64_t)(uintptr_t)name;
+  p.platform = platform; p.ret = 0; seam(C_RS_SetSyncPlatforms, &p); return (uint8_t)p.ret; }
+static uint64_t THISCALL irs_FileWriteStreamOpen(struct w_iface *s, const char *name)
+{ struct sp_rs_name_u64 p; p.handle = s->handle; p.name = (uint64_t)(uintptr_t)name; p.ret = 0;
+  seam(C_RS_FileWriteStreamOpen, &p); return p.ret; }
+static uint8_t THISCALL irs_FileWriteStreamWriteChunk(struct w_iface *s, uint64_t stream, const void *data, int32_t count)
+{ struct sp_rs_streamchunk p; p.handle = s->handle; p.stream = stream;
+  p.data = (uint64_t)(uintptr_t)data; p.count = count; p.ret = 0;
+  seam(C_RS_FileWriteStreamWriteChunk, &p); return (uint8_t)p.ret; }
+static uint8_t THISCALL irs_FileWriteStreamClose(struct w_iface *s, uint64_t stream)
+{ struct sp_rs_stream p; p.handle = s->handle; p.stream = stream; p.ret = 0;
+  seam(C_RS_FileWriteStreamClose, &p); return (uint8_t)p.ret; }
+static uint8_t THISCALL irs_FileWriteStreamCancel(struct w_iface *s, uint64_t stream)
+{ struct sp_rs_stream p; p.handle = s->handle; p.stream = stream; p.ret = 0;
+  seam(C_RS_FileWriteStreamCancel, &p); return (uint8_t)p.ret; }
+static uint8_t THISCALL irs_FileExists(struct w_iface *s, const char *name)
+{ struct sp_rs_name_i32 p; p.handle = s->handle; p.name = (uint64_t)(uintptr_t)name; p.ret = 0;
+  seam(C_RS_FileExists, &p);
+  dbg("shim: FileExists(\"%s\") -> %d", name ? name : "(null)", p.ret);
+  return (uint8_t)p.ret; }
+static uint8_t THISCALL irs_FilePersisted(struct w_iface *s, const char *name)
+{ struct sp_rs_name_i32 p; p.handle = s->handle; p.name = (uint64_t)(uintptr_t)name; p.ret = 0;
+  seam(C_RS_FilePersisted, &p); return (uint8_t)p.ret; }
+static int32_t THISCALL irs_GetFileSize(struct w_iface *s, const char *name)
+{ struct sp_rs_name_i32 p; p.handle = s->handle; p.name = (uint64_t)(uintptr_t)name; p.ret = 0;
+  seam(C_RS_GetFileSize, &p); return p.ret; }
+static int64_t THISCALL irs_GetFileTimestamp(struct w_iface *s, const char *name)
+{ struct sp_rs_name_i64 p; p.handle = s->handle; p.name = (uint64_t)(uintptr_t)name; p.ret = 0;
+  seam(C_RS_GetFileTimestamp, &p); return p.ret; }
+static int32_t THISCALL irs_GetSyncPlatforms(struct w_iface *s, const char *name)
+{ struct sp_rs_name_i32 p; p.handle = s->handle; p.name = (uint64_t)(uintptr_t)name; p.ret = 0;
+  seam(C_RS_GetSyncPlatforms, &p); return p.ret; }
+static int32_t THISCALL irs_GetFileCount(struct w_iface *s)
+{ struct sp_rs_noarg p; p.handle = s->handle; p.ret = 0; seam(C_RS_GetFileCount, &p);
+  dbg("shim: GetFileCount() -> %d", p.ret); return p.ret; }
+static const char * THISCALL irs_GetFileNameAndSize(struct w_iface *s, int32_t index, int32_t *size_out)
+{ struct sp_rs_namesize p; const char *r; p.handle = s->handle;
+  p.size_out = (uint64_t)(uintptr_t)size_out; p.index = index; p.ret = 0;
+  seam(C_RS_GetFileNameAndSize, &p);
+  r = native_str(p.ret);
+  dbg("shim: GetFileNameAndSize(%d) -> %s", index, r ? r : "(null)");
+  return r; }
+static uint8_t THISCALL irs_GetQuota(struct w_iface *s, uint64_t *total, uint64_t *avail)
+{ struct sp_rs_quota p; p.handle = s->handle; p.total = (uint64_t)(uintptr_t)total;
+  p.avail = (uint64_t)(uintptr_t)avail; p.ret = 0; seam(C_RS_GetQuota, &p); return (uint8_t)p.ret; }
+static uint8_t THISCALL irs_IsCloudEnabledForAccount(struct w_iface *s)
+{ struct sp_rs_noarg p; p.handle = s->handle; p.ret = 0;
+  seam(C_RS_IsCloudEnabledForAccount, &p); return (uint8_t)p.ret; }
+static uint8_t THISCALL irs_IsCloudEnabledForApp(struct w_iface *s)
+{ struct sp_rs_noarg p; p.handle = s->handle; p.ret = 0;
+  seam(C_RS_IsCloudEnabledForApp, &p);
+  dbg("shim: IsCloudEnabledForApp() -> %d", p.ret); return (uint8_t)p.ret; }
+static void THISCALL irs_SetCloudEnabledForApp(struct w_iface *s, int32_t enabled)
+{ struct sp_rs_setcloud p; p.handle = s->handle; p.enabled = enabled;
+  seam(C_RS_SetCloudEnabledForApp, &p); }
+
 static void build_vtables(void)
 {
     vt_fill_stubs();
@@ -1085,6 +1184,36 @@ static void build_vtables(void)
     wire("SteamInput002", "GetConnectedControllers", (const void *)iin_GetConnectedControllers);
     wire("SteamInput006", "GetConnectedControllers", (const void *)iin_GetConnectedControllers);
 
+    /* ISteamRemoteStorage — the Cloud file surface, slots 0-23 (#43). One
+     * wire_all per method reaches every generated version: slots 0-23 are
+     * shape-identical from v001 to v016, so nothing here can land in the wrong
+     * slot or pop the wrong bytes. Slots 24-58 (UGC/workshop/video) stay stubbed
+     * on purpose — a different subsystem, and a stub there is a dead feature
+     * rather than an invisible save. */
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "FileWrite", (const void *)irs_FileWrite);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "FileRead", (const void *)irs_FileRead);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "FileWriteAsync", (const void *)irs_FileWriteAsync);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "FileReadAsync", (const void *)irs_FileReadAsync);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "FileReadAsyncComplete", (const void *)irs_FileReadAsyncComplete);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "FileForget", (const void *)irs_FileForget);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "FileDelete", (const void *)irs_FileDelete);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "FileShare", (const void *)irs_FileShare);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "SetSyncPlatforms", (const void *)irs_SetSyncPlatforms);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "FileWriteStreamOpen", (const void *)irs_FileWriteStreamOpen);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "FileWriteStreamWriteChunk", (const void *)irs_FileWriteStreamWriteChunk);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "FileWriteStreamClose", (const void *)irs_FileWriteStreamClose);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "FileWriteStreamCancel", (const void *)irs_FileWriteStreamCancel);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "FileExists", (const void *)irs_FileExists);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "FilePersisted", (const void *)irs_FilePersisted);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "GetFileSize", (const void *)irs_GetFileSize);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "GetFileTimestamp", (const void *)irs_GetFileTimestamp);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "GetSyncPlatforms", (const void *)irs_GetSyncPlatforms);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "GetFileCount", (const void *)irs_GetFileCount);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "GetFileNameAndSize", (const void *)irs_GetFileNameAndSize);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "GetQuota", (const void *)irs_GetQuota);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "IsCloudEnabledForAccount", (const void *)irs_IsCloudEnabledForAccount);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "IsCloudEnabledForApp", (const void *)irs_IsCloudEnabledForApp);
+    wire_all("STEAMREMOTESTORAGE_INTERFACE_VERSION016", "SetCloudEnabledForApp", (const void *)irs_SetCloudEnabledForApp);
 }
 
 /* ---- flat exports ------------------------------------------------------- */

--- a/src/shim/shim_unix.cpp
+++ b/src/shim/shim_unix.cpp
@@ -620,6 +620,89 @@ static NTSTATUS u_overlay_setnotifyinset(void *args)
     return 0;
 }
 
+/* ---- ISteamRemoteStorage (slots 0-23) — the Steam Cloud file surface (#43).
+ *
+ * A title with cloud saves does not open userdata/<id>/<appid>/remote itself; it
+ * asks this interface. Stubbed, FileExists() is false and a complete save is
+ * invisible — Space Marine offers only "New Campaign" (#43). The handle casts to
+ * one class for every version because ISteamRemoteStorage has no same-name
+ * overload anywhere, so Itanium order == MSVC order (see steam_ifaces.h). -------- */
+#define RS(h) ((ISteamRemoteStorage016 *)(h))
+static NTSTATUS u_rs_filewrite(void *args)
+{ auto *p = (sp_rs_filedata *)args;
+  p->ret = RS(p->handle)->FileWrite((const char *)p->name, (const void *)p->data, p->count) ? 1 : 0;
+  ulog("FileWrite(\"%s\", %d bytes) -> %d", (const char *)p->name, p->count, p->ret); return 0; }
+static NTSTATUS u_rs_fileread(void *args)
+{ auto *p = (sp_rs_filedata *)args;
+  p->ret = RS(p->handle)->FileRead((const char *)p->name, (void *)p->data, p->count);
+  ulog("FileRead(\"%s\", %d) -> %d bytes", (const char *)p->name, p->count, p->ret); return 0; }
+static NTSTATUS u_rs_filewriteasync(void *args)
+{ auto *p = (sp_rs_writeasync *)args;
+  p->ret = RS(p->handle)->FileWriteAsync((const char *)p->name, (const void *)p->data, (uint32_t)p->count);
+  ulog("FileWriteAsync(\"%s\", %d bytes) -> call 0x%llx", (const char *)p->name, p->count,
+       (unsigned long long)p->ret); return 0; }
+static NTSTATUS u_rs_filereadasync(void *args)
+{ auto *p = (sp_rs_readasync *)args;
+  p->ret = RS(p->handle)->FileReadAsync((const char *)p->name, (uint32_t)p->offset, (uint32_t)p->toread);
+  ulog("FileReadAsync(\"%s\", off=%d, %d) -> call 0x%llx", (const char *)p->name, p->offset,
+       p->toread, (unsigned long long)p->ret); return 0; }
+static NTSTATUS u_rs_filereadasyncdone(void *args)
+{ auto *p = (sp_rs_readasyncdone *)args;
+  p->ret = RS(p->handle)->FileReadAsyncComplete(p->call, (void *)p->data, (uint32_t)p->toread) ? 1 : 0;
+  ulog("FileReadAsyncComplete(0x%llx, %d) -> %d", (unsigned long long)p->call, p->toread, p->ret); return 0; }
+static NTSTATUS u_rs_fileforget(void *args)
+{ auto *p = (sp_rs_name_i32 *)args; p->ret = RS(p->handle)->FileForget((const char *)p->name) ? 1 : 0; return 0; }
+static NTSTATUS u_rs_filedelete(void *args)
+{ auto *p = (sp_rs_name_i32 *)args; p->ret = RS(p->handle)->FileDelete((const char *)p->name) ? 1 : 0;
+  ulog("FileDelete(\"%s\") -> %d", (const char *)p->name, p->ret); return 0; }
+static NTSTATUS u_rs_fileshare(void *args)
+{ auto *p = (sp_rs_name_u64 *)args; p->ret = RS(p->handle)->FileShare((const char *)p->name); return 0; }
+static NTSTATUS u_rs_setsyncplatforms(void *args)
+{ auto *p = (sp_rs_syncplat *)args;
+  p->ret = RS(p->handle)->SetSyncPlatforms((const char *)p->name, p->platform) ? 1 : 0; return 0; }
+static NTSTATUS u_rs_streamopen(void *args)
+{ auto *p = (sp_rs_name_u64 *)args; p->ret = RS(p->handle)->FileWriteStreamOpen((const char *)p->name);
+  ulog("FileWriteStreamOpen(\"%s\") -> 0x%llx", (const char *)p->name, (unsigned long long)p->ret); return 0; }
+static NTSTATUS u_rs_streamchunk(void *args)
+{ auto *p = (sp_rs_streamchunk *)args;
+  p->ret = RS(p->handle)->FileWriteStreamWriteChunk(p->stream, (const void *)p->data, p->count) ? 1 : 0; return 0; }
+static NTSTATUS u_rs_streamclose(void *args)
+{ auto *p = (sp_rs_stream *)args; p->ret = RS(p->handle)->FileWriteStreamClose(p->stream) ? 1 : 0;
+  ulog("FileWriteStreamClose(0x%llx) -> %d", (unsigned long long)p->stream, p->ret); return 0; }
+static NTSTATUS u_rs_streamcancel(void *args)
+{ auto *p = (sp_rs_stream *)args; p->ret = RS(p->handle)->FileWriteStreamCancel(p->stream) ? 1 : 0; return 0; }
+static NTSTATUS u_rs_fileexists(void *args)
+{ auto *p = (sp_rs_name_i32 *)args; p->ret = RS(p->handle)->FileExists((const char *)p->name) ? 1 : 0;
+  ulog("FileExists(\"%s\") -> %d", (const char *)p->name, p->ret); return 0; }
+static NTSTATUS u_rs_filepersisted(void *args)
+{ auto *p = (sp_rs_name_i32 *)args; p->ret = RS(p->handle)->FilePersisted((const char *)p->name) ? 1 : 0; return 0; }
+static NTSTATUS u_rs_getfilesize(void *args)
+{ auto *p = (sp_rs_name_i32 *)args; p->ret = RS(p->handle)->GetFileSize((const char *)p->name);
+  ulog("GetFileSize(\"%s\") -> %d", (const char *)p->name, p->ret); return 0; }
+static NTSTATUS u_rs_getfiletimestamp(void *args)
+{ auto *p = (sp_rs_name_i64 *)args; p->ret = RS(p->handle)->GetFileTimestamp((const char *)p->name); return 0; }
+static NTSTATUS u_rs_getsyncplatforms(void *args)
+{ auto *p = (sp_rs_name_i32 *)args; p->ret = RS(p->handle)->GetSyncPlatforms((const char *)p->name); return 0; }
+static NTSTATUS u_rs_getfilecount(void *args)
+{ auto *p = (sp_rs_noarg *)args; p->ret = RS(p->handle)->GetFileCount();
+  ulog("GetFileCount() -> %d", p->ret); return 0; }
+static NTSTATUS u_rs_getfilenameandsize(void *args)
+{ auto *p = (sp_rs_namesize *)args;
+  p->ret = (uint64_t)RS(p->handle)->GetFileNameAndSize(p->index, (int32_t *)p->size_out);
+  ulog("GetFileNameAndSize(%d) -> %s", p->index, p->ret ? (const char *)p->ret : "(null)"); return 0; }
+static NTSTATUS u_rs_getquota(void *args)
+{ auto *p = (sp_rs_quota *)args;
+  p->ret = RS(p->handle)->GetQuota((uint64_t *)p->total, (uint64_t *)p->avail) ? 1 : 0; return 0; }
+static NTSTATUS u_rs_cloudforaccount(void *args)
+{ auto *p = (sp_rs_noarg *)args; p->ret = RS(p->handle)->IsCloudEnabledForAccount() ? 1 : 0;
+  ulog("IsCloudEnabledForAccount() -> %d", p->ret); return 0; }
+static NTSTATUS u_rs_cloudforapp(void *args)
+{ auto *p = (sp_rs_noarg *)args; p->ret = RS(p->handle)->IsCloudEnabledForApp() ? 1 : 0;
+  ulog("IsCloudEnabledForApp() -> %d", p->ret); return 0; }
+static NTSTATUS u_rs_setcloudforapp(void *args)
+{ auto *p = (sp_rs_setcloud *)args; RS(p->handle)->SetCloudEnabledForApp(p->enabled != 0);
+  ulog("SetCloudEnabledForApp(%d)", p->enabled); return 0; }
+
 extern "C" {
 NTSTATUS __wine_unix_lib_init(void) { return 0; }
 
@@ -654,6 +737,13 @@ const unixlib_entry_t __wine_unix_call_funcs[] = {
     u_fr_ov_invite, u_fr_ov_remoteplay, u_fr_ov_connectstring, u_fr_ov_registerprotocol,
     u_overlay_isenabled, u_overlay_needspresent,
     u_overlay_setnotifypos, u_overlay_setnotifyinset,
+    u_rs_filewrite, u_rs_fileread, u_rs_filewriteasync, u_rs_filereadasync,
+    u_rs_filereadasyncdone, u_rs_fileforget, u_rs_filedelete, u_rs_fileshare,
+    u_rs_setsyncplatforms, u_rs_streamopen, u_rs_streamchunk, u_rs_streamclose,
+    u_rs_streamcancel, u_rs_fileexists, u_rs_filepersisted, u_rs_getfilesize,
+    u_rs_getfiletimestamp, u_rs_getsyncplatforms, u_rs_getfilecount,
+    u_rs_getfilenameandsize, u_rs_getquota, u_rs_cloudforaccount,
+    u_rs_cloudforapp, u_rs_setcloudforapp,
 };
 const unixlib_entry_t __wine_unix_call_wow64_funcs[] = {
     u_create_interface, u_bgetcallback, u_freelast, u_apicallresult, u_release_tls,
@@ -680,6 +770,13 @@ const unixlib_entry_t __wine_unix_call_wow64_funcs[] = {
     u_fr_ov_invite, u_fr_ov_remoteplay, u_fr_ov_connectstring, u_fr_ov_registerprotocol,
     u_overlay_isenabled, u_overlay_needspresent,
     u_overlay_setnotifypos, u_overlay_setnotifyinset,
+    u_rs_filewrite, u_rs_fileread, u_rs_filewriteasync, u_rs_filereadasync,
+    u_rs_filereadasyncdone, u_rs_fileforget, u_rs_filedelete, u_rs_fileshare,
+    u_rs_setsyncplatforms, u_rs_streamopen, u_rs_streamchunk, u_rs_streamclose,
+    u_rs_streamcancel, u_rs_fileexists, u_rs_filepersisted, u_rs_getfilesize,
+    u_rs_getfiletimestamp, u_rs_getsyncplatforms, u_rs_getfilecount,
+    u_rs_getfilenameandsize, u_rs_getquota, u_rs_cloudforaccount,
+    u_rs_cloudforapp, u_rs_setcloudforapp,
 };
 
 /* A short array silently maps every opcode past the end onto garbage, and a

--- a/src/shim/steam_ifaces.h
+++ b/src/shim/steam_ifaces.h
@@ -22,6 +22,10 @@ typedef int32_t  HSteamUser;
 typedef uint64_t CSteamID_t;       // CSteamID: one uint64 by value (pack(1))
 typedef uint64_t SteamAPICall_t;
 typedef uint32_t AppId_t;
+typedef uint64_t UGCHandle_t;
+typedef uint64_t UGCFileWriteStreamHandle_t;
+typedef uint64_t PublishedFileId_t;
+typedef int32_t  ERemoteStoragePlatform;
 
 class ISteamUser {
  public:
@@ -198,6 +202,52 @@ class ISteamInput006 {
   virtual int  GetConnectedControllers(uint64_t*) = 0;                 // 6
   // ... truncated
 };
+
+// ISteamRemoteStorage, slots 0-23 — the Steam Cloud file surface (#43).
+//
+// This is the interface a title with cloud saves reads its save THROUGH. Left
+// stubbed, FileExists() answers false and a game with a complete save on disk
+// offers only "New Campaign" (Space Marine, 3169520); FileWrite() answers false
+// alongside it, so the same run cannot save either.
+//
+// The class-cast pattern is safe here for a reason worth stating: NO version of
+// ISteamRemoteStorage declares a same-name overload (checked against
+// vtables.json), so the dylib's Itanium order equals the MSVC order the PE side
+// holds. The ISteamFriends caveat — where an overload set swaps slots between
+// the two ABIs — does not apply, and neither does its slot-passing workaround.
+//
+// Slot order from Proton's winISteamRemoteStorage.c; slots 0-23 are identical
+// from v001 through v016. Tail (UGC/workshop/video, slots 24-58) truncated: a
+// different subsystem, and nothing we call reaches past slot 23.
+class ISteamRemoteStorage016 {
+ public:
+  virtual bool     FileWrite(const char*, const void*, int32_t) = 0;            // 0
+  virtual int32_t  FileRead(const char*, void*, int32_t) = 0;                   // 1
+  virtual SteamAPICall_t FileWriteAsync(const char*, const void*, uint32_t) = 0; // 2
+  virtual SteamAPICall_t FileReadAsync(const char*, uint32_t, uint32_t) = 0;    // 3
+  virtual bool     FileReadAsyncComplete(SteamAPICall_t, void*, uint32_t) = 0;  // 4
+  virtual bool     FileForget(const char*) = 0;                                 // 5
+  virtual bool     FileDelete(const char*) = 0;                                 // 6
+  virtual SteamAPICall_t FileShare(const char*) = 0;                            // 7
+  virtual bool     SetSyncPlatforms(const char*, ERemoteStoragePlatform) = 0;   // 8
+  virtual UGCFileWriteStreamHandle_t FileWriteStreamOpen(const char*) = 0;      // 9
+  virtual bool     FileWriteStreamWriteChunk(UGCFileWriteStreamHandle_t, const void*, int32_t) = 0; // 10
+  virtual bool     FileWriteStreamClose(UGCFileWriteStreamHandle_t) = 0;        // 11
+  virtual bool     FileWriteStreamCancel(UGCFileWriteStreamHandle_t) = 0;       // 12
+  virtual bool     FileExists(const char*) = 0;                                 // 13
+  virtual bool     FilePersisted(const char*) = 0;                              // 14
+  virtual int32_t  GetFileSize(const char*) = 0;                                // 15
+  virtual int64_t  GetFileTimestamp(const char*) = 0;                           // 16
+  virtual ERemoteStoragePlatform GetSyncPlatforms(const char*) = 0;             // 17
+  virtual int32_t  GetFileCount() = 0;                                          // 18
+  virtual const char* GetFileNameAndSize(int32_t, int32_t*) = 0;                // 19
+  virtual bool     GetQuota(uint64_t*, uint64_t*) = 0;                          // 20
+  virtual bool     IsCloudEnabledForAccount() = 0;                              // 21
+  virtual bool     IsCloudEnabledForApp() = 0;                                  // 22
+  virtual void     SetCloudEnabledForApp(bool) = 0;                             // 23
+  // ... truncated
+};
+
 
 // ISteamFriends VERSION017 leading block. Only GetPersonaName is needed so far,
 // and it is the same class of bug as ISteamApps::GetCurrentGameLanguage above:


### PR DESCRIPTION
Closes #43.

## The bug

Space Marine MCE (3169520) offers only **New Campaign** with a complete save on disk.

The save is fine and cloud sync is fine: the three files under
`userdata/53965002/3169520/remote/` are byte-identical (SHA-1) between the bottle's Steam
library and native macOS Steam's, and both `remotecache.vdf` report `syncstate 1` with
matching `remotetime`.

The game never opens them. It stores its campaign save **only in Steam Cloud**, so it asks
`ISteamRemoteStorage::FileExists("smsave0.dsav")`. The shim acquired the interface and
handed back a real, slot-exact 59-slot table — with nothing wired into any slot:

```
GetISteamGenericInterface(u=1,pipe=1,"STEAMREMOTESTORAGE_INTERFACE_VERSION016") -> 0x7fb8a285c810
```

Every slot was still the generated stub that calls `vt_unmapped` and returns `0`. So
`FileExists` -> false, `GetFileCount` -> 0, `FileRead` -> nothing. `FileWrite` was stubbed
alongside them, so the same run could not save either.

#29's failure shape on a different interface: #29 fixed *which versions get a table*, not
*which methods get wired into one*. Neither proof title uses Cloud, so
`interface-versions.txt` — derived from their import libraries — never exercised this path.

## The fix

Wires slots **0-23**: sync read/write, async read/write, the write-stream family,
existence/size/timestamp, enumeration, quota, and the cloud-enabled predicates. Four files,
the same shape as every other interface block:

| file | what |
| --- | --- |
| `shim_abi.h` | 24 opcodes + 14 params structs, appended after the overlay block so existing indices are undisturbed |
| `steam_ifaces.h` | `ISteamRemoteStorage016`, slots 0-23, tail truncated |
| `shim_unix.cpp` | 24 handlers + both dispatch tables |
| `shim_pe.c` | 24 thunks + 24 `wire_all` calls |

Two properties checked against `vtables.json` rather than assumed make the plain
`wire_all` + class-cast pattern safe here:

- **No same-name overload in any version**, so the dylib's Itanium order equals the MSVC
  order the PE side holds — the ISteamFriends slot-passing workaround is not needed.
- **Slots 0-23 are shape-identical from v001 through v016**, so one `wire_all` per method
  reaches every generated version.

`GetFileNameAndSize` is the one method whose result cannot pass straight through: its
`const char*` return points into the dylib's heap above 4 GB, so it goes through
`native_str` like `GetIPCountry`. Every other buffer is an address the game owns, which
zero-extends on i386 and is written in place.

Slots 24-58 (UGC, workshop publishing, video, local-file-change batching) stay stubbed
deliberately: a different subsystem, unexercised by any title in hand, and a stub there is
a dead feature rather than an invisible save.

## Checks

Both build gates pass:

```
seam ABI bitness-neutral: 275 sizes/offsets identical under i686 and x86_64
i386 thiscall cleanup verified: 6654 entry points match Proton exactly
```

The second is the load-bearing one — it proves each of the 24 new thunks pops exactly the
bytes its MSVC caller pushed, which on i386 is the difference between a wrong answer and a
corrupted stack.

## Still to confirm — live run

**Not yet verified against the running game.** Payload is deployed
(`./src/installer/install.sh`). Acceptance is: Space Marine MCE offers **Resume**, loads the
existing save, and writes a new one that survives a relaunch.

`shim-unix.log` should now show `FileExists("smsave0.dsav") -> 1` and a `FileRead` returning
~22266 bytes where previously there was nothing after the interface acquisition line.