### PR TITLE
Report unmapped vtable slots into shim-unix.log, unconditionally

### DIFF
--- a/src/shim/shim_abi.h
+++ b/src/shim/shim_abi.h
@@ -204,6 +204,16 @@ enum shim_call
     C_RS_IsCloudEnabledForApp,
     C_RS_SetCloudEnabledForApp,
 
+    /* Diagnostics (#45). The PE half's own dbg() writes to OutputDebugStringA and
+     * to a file only when SHIM_PE_LOG is set, so in a normal run it writes
+     * nowhere. That is fine for tracing and wrong for the one message that must
+     * never be missed: a title calling a vtable slot nothing is wired into. That
+     * call silently returns 0, and "no error" then reads as "works" — which is
+     * how a complete cloud save stayed invisible through a whole play session
+     * (#43). This opcode puts that one line in shim-unix.log, where every other
+     * half of the stack already reports. */
+    C_Log,
+
     C_COUNT
 };
 
@@ -317,3 +327,6 @@ struct sp_rs_noarg         { uint64_t handle; int32_t ret; };                   
 struct sp_rs_namesize      { uint64_t handle; uint64_t size_out; uint64_t ret; int32_t index; }; /* GetFileNameAndSize -> const char* */
 struct sp_rs_quota         { uint64_t handle; uint64_t total; uint64_t avail; int32_t ret; };    /* GetQuota -> bool */
 struct sp_rs_setcloud      { uint64_t handle; int32_t enabled; };                 /* SetCloudEnabledForApp -> void */
+
+/* ---- diagnostics (#45) ---- */
+struct sp_log              { uint64_t msg; };                                     /* a PE-side line, into shim-unix.log */

--- a/src/shim/shim_pe.c
+++ b/src/shim/shim_pe.c
@@ -215,8 +215,51 @@ struct w_iface { const void **vtable; uint64_t handle; };
 static unsigned int vt_unmapped(const char *version, int slot, const char *name);
 #include "shim_vtables.h"
 
+/* A title just called a slot nothing is wired into, and got 0 back.
+ *
+ * That 0 is the most expensive value in this file. It is not an error the caller
+ * can see: FileExists answers "no such save", GetFileCount answers "no files",
+ * BIsSubscribed answers "not owned" — each a plausible answer the title acts on.
+ * Space Marine spent a whole session offering "New Campaign" over a complete
+ * cloud save because of exactly this, and nothing anywhere said why (#43).
+ *
+ * dbg() alone was not enough: it writes to OutputDebugStringA, and to a file
+ * only when SHIM_PE_LOG is set, so a normal run recorded nothing. So this also
+ * crosses the seam into shim-unix.log, unconditionally — the whole point is to
+ * be readable from a run nobody thought to instrument in advance.
+ *
+ * Once per (version, slot): a method called every frame would otherwise bury the
+ * log it is supposed to be found in. Both strings come from the generated tables
+ * and are static, so comparing pointers is the identity we want. Past the cap we
+ * stop recording rather than stop logging — a truncated diagnosis is worse than
+ * a repetitive one. */
 static unsigned int vt_unmapped(const char *version, int slot, const char *name)
-{ dbg("shim: %s slot %d %s (unmapped)", version, slot, name); return 0; }
+{
+    static const char *seen_ver[256];
+    static int seen_slot[256];
+    static int nseen;
+    struct sp_log p;
+    char msg[320];
+    int i;
+
+    dbg("shim: %s slot %d %s (unmapped)", version, slot, name);
+
+    for (i = 0; i < nseen; i++)
+        if (seen_ver[i] == version && seen_slot[i] == slot) return 0;
+    if (nseen < (int)(sizeof seen_ver / sizeof *seen_ver)) {
+        seen_ver[nseen] = version; seen_slot[nseen] = slot; nseen++;
+    }
+
+    snprintf(msg, sizeof msg,
+             "UNMAPPED %s::%s (slot %d) -> returned 0. The title called a method "
+             "this shim has a correct table for but no thunk behind. The 0 is not "
+             "an error it can see, so whatever it does next is built on a wrong "
+             "answer. Wire it in shim_pe.c (#45).",
+             version ? version : "(unknown)", name ? name : "(unknown)", slot);
+    p.msg = (uint64_t)(uintptr_t)msg;
+    seam(C_Log, &p);
+    return 0;
+}
 
 static const struct vt_desc *vt_find(const char *ver)
 {

--- a/src/shim/shim_unix.cpp
+++ b/src/shim/shim_unix.cpp
@@ -703,6 +703,15 @@ static NTSTATUS u_rs_setcloudforapp(void *args)
 { auto *p = (sp_rs_setcloud *)args; RS(p->handle)->SetCloudEnabledForApp(p->enabled != 0);
   ulog("SetCloudEnabledForApp(%d)", p->enabled); return 0; }
 
+/* ---- diagnostics (#45) — the PE half's one must-not-be-missed line ---------
+ *
+ * shim_pe.c's dbg() goes to OutputDebugStringA and, only when SHIM_PE_LOG is
+ * set, to a file: in a normal run, nowhere. An unmapped vtable slot needs to be
+ * louder than that, because its failure mode is a silent 0 that a title builds
+ * on (#43). This lands it in shim-unix.log beside everything else. */
+static NTSTATUS u_log(void *args)
+{ auto *p = (sp_log *)args; ulog("%s", (const char *)p->msg); return 0; }
+
 extern "C" {
 NTSTATUS __wine_unix_lib_init(void) { return 0; }
 
@@ -744,6 +753,7 @@ const unixlib_entry_t __wine_unix_call_funcs[] = {
     u_rs_getfiletimestamp, u_rs_getsyncplatforms, u_rs_getfilecount,
     u_rs_getfilenameandsize, u_rs_getquota, u_rs_cloudforaccount,
     u_rs_cloudforapp, u_rs_setcloudforapp,
+    u_log,
 };
 const unixlib_entry_t __wine_unix_call_wow64_funcs[] = {
     u_create_interface, u_bgetcallback, u_freelast, u_apicallresult, u_release_tls,
@@ -777,6 +787,7 @@ const unixlib_entry_t __wine_unix_call_wow64_funcs[] = {
     u_rs_getfiletimestamp, u_rs_getsyncplatforms, u_rs_getfilecount,
     u_rs_getfilenameandsize, u_rs_getquota, u_rs_cloudforaccount,
     u_rs_cloudforapp, u_rs_setcloudforapp,
+    u_log,
 };
 
 /* A short array silently maps every opcode past the end onto garbage, and a


### PR DESCRIPTION
Refs #45. **Stacked on #44** — base retargets to `main` when that merges.

## Why

An unwired slot returns `0`, and that `0` is the most expensive value in the shim. It is not
an error the caller can see:

| call | stub answers | title concludes |
| --- | --- | --- |
| `FileExists` | false | no save exists |
| `GetFileCount` | 0 | cloud is empty |
| `BIsSubscribed` | false | not owned |
| `Init` | false | no controller |

Each is plausible, so the title acts on it and fails somewhere unrelated.

#43 is what that costs: Space Marine offered "New Campaign" over a complete cloud save for a
whole session, and nothing anywhere named why. `vt_unmapped` did report — through `dbg()`,
which writes to `OutputDebugStringA` and to a file only when `SHIM_PE_LOG` is set. A normal
run recorded nothing, and "no error" read as "works".

This is the missing half of #29. That ticket made a missing **version** loud:

```
*** NO VTABLE for interface version "..." -> returning NULL ***
```

A missing **method** stayed silent — the same bug one level down.

## What changed

Adds `C_Log` and routes `vt_unmapped` across the seam into `shim-unix.log`, where every other
half of the stack already reports:

```
UNMAPPED SteamController008::Init (slot 0) -> returned 0. The title called a method this
shim has a correct table for but no thunk behind. The 0 is not an error it can see, so
whatever it does next is built on a wrong answer. Wire it in shim_pe.c (#45).
```

Three deliberate details:

- **Deduped per (version, slot).** A method called every frame would bury the log it is meant
  to be found in. Both strings come from the generated tables and are static, so pointer
  identity is the correct comparison.
- **Past the 256-entry cap it stops recording, not logging.** A truncated diagnosis is worse
  than a repetitive one.
- **The line says what to do.** The audience is whoever is staring at a title behaving
  strangely with no idea this layer exists.

`dbg()` still fires as before, so `SHIM_PE_LOG` tracing is unchanged.

## Checks

```
seam ABI bitness-neutral: 277 sizes/offsets identical under i686 and x86_64
i386 thiscall cleanup verified: 6654 entry points match Proton exactly
```

## Not yet verified live

Deployed but not yet observed against a running title. Expected on the next Space Marine
launch: `UNMAPPED` lines for `ISteamController` / the unwired `ISteamInput` slots it touches,
and — the point of the change — **no** `UNMAPPED` line for any `ISteamRemoteStorage` method,
since #44 wired the ones it calls.