### PR TITLE
Declare the two marshalling facts a signature cannot carry

### DIFF
--- a/docs/adr/0009-marshalling-facts-are-declared-not-inferred.md
+++ b/docs/adr/0009-marshalling-facts-are-declared-not-inferred.md
@@ -1,0 +1,108 @@
+# 9. Marshalling facts are declared, not inferred
+
+Date: 2026-08-26
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0008 left 44 refused methods. Two classes were recorded as needing work the
+generator could not do:
+
+> `void*` return (4) — returns a native pointer with no length to copy down by
+>
+> struct layout differs on x86_64 (6) — needs a converter, and the direction and
+> extent are not in the signature
+
+The first was over-stated. Of the four, one is an ordinary interface getter
+Valve retired in place — `DEPRECATED_GetISteamUnifiedMessages` — which
+`wire_getters` already handles for every sibling and missed only because its
+prefix test is `GetISteam` and the name begins `DEPRECATED_GetISteam`. Another,
+`GetServerDetails`, returns a pointer to a struct Proton states both sides agree
+on, which on x86_64 is the same move a `const char *` return already makes: one
+address space, so the PE dereferences the native object in place. Only two
+genuinely resist — both return interface pointers we cannot hand a title without
+presenting a PE vtable for them.
+
+The second was accurate about the obstacle and wrong about its size. The
+conversion itself is entirely mechanical: Proton states both layouts field for
+field, the field NAMES and their order are identical between them, and the only
+difference is where the explicit `__pad_N[]` members fall. What is not derivable
+is two facts per parameter, and the evidence is worth stating because the
+tempting heuristics both fail:
+
+- **Direction is not const-ness.** `ISteamParties::CreateBeacon` takes a
+  non-const `w_SteamPartyBeaconLocation_t *` that is an **input** — the location
+  to open a beacon at. The other five non-const cases are outputs. A rule keyed
+  on `const` would have converted `CreateBeacon`'s input in the wrong direction
+  and returned the caller its own uninitialised buffer.
+- **Extent is not in the type.** `GetAvailableBeaconLocations` fills an *array*
+  whose element count is the next parameter.
+
+## Decision
+
+**Two facts per parameter are declared in `overrides.json`; everything else is
+generated.**
+
+- A new `marshal` section names, per (interface, method, argument): the
+  direction, and either a literal count or the parameter the count comes from.
+  Without it a divergent-layout parameter is still refused — the generator never
+  guesses either fact.
+
+- `arg` is the argument index and `param` is the name it must have. The name is
+  **checked at generation time against every version**, so a version that renames
+  or reorders parameters fails the build rather than marshalling the wrong one.
+
+- Converters are generated from Proton's two field lists, matched by name, with
+  `__pad_N[]` dropped — those exist to pin the layout, and copying them would be
+  copying the difference the converter absorbs. The generator refuses outright if
+  the two field name sets are not equal, because then they are not the same
+  struct and a field-by-field copy is not a conversion.
+
+- `check_convert.py` proves the copy is complete, and does so **without reading
+  the converter**: it takes Proton's field list from `structs.json`, fills the
+  Windows struct with one byte pattern and the destination with another, runs
+  `w2u` then `u2w`, and compares every declared field. A field the converter
+  never copies keeps the second pattern and is caught. The check and the
+  generator derive from the same source by different routes, so they would have
+  to be wrong in the same way.
+
+- `wire_getters` matches `DEPRECATED_GetISteam*` as well as `GetISteam*`, and a
+  return that is a pointer to an agreed-on struct is generated for x86_64 only,
+  the same bitness-scoping ADR 0008 introduced.
+
+## Alternatives rejected
+
+**Infer direction from `const`.** `CreateBeacon` is the counter-example, and it
+is not an edge case — it is one of the six.
+
+**Convert in both directions always.** Safe for `in` and `inout`, and it would
+have avoided declaring direction. Rejected because for a pure `out` it reads
+uninitialised PE memory into the temporary before the call: harmless in practice,
+but it makes every such call depend on the caller having zeroed a buffer it has
+no contract to zero. The generated handler zeroes the temporary instead, which
+is the same cost and no assumption.
+
+**Hand-write the six.** Six methods, three structs, and a converter each. The
+converters would then be transcriptions with no gate behind them — the exact
+shape ADR 0007 removed, reintroduced at the point where a mistake is a silently
+wrong field rather than a crash.
+
+## Consequences
+
+- Residue **44 → 37**. The divergent-layout class is closed entirely (6 → 0) and
+  native-pointer returns go 4 → 2. Slots wired **5,191 → 5,218**; shapes
+  **1,143 → 1,152**, of which 31 are x86_64-only.
+- `#47` ISteamUGC, `#60` ISteamParties, `#73` ISteamUserStats and `#55`
+  ISteamNetworkingUtils lose all or most of their remaining residue.
+- The 37 left are 25 with no readable signature, 10 function-pointer parameters,
+  and 2 interface-pointer returns. All three need a mechanism the seam does not
+  have or logic Proton hand-wrote; none is a generator change.
+- The build gains one gate, and it was checked the way the others were: dropping
+  a single field from a generated converter makes `check_convert.py` name it and
+  fail. A gate that cannot go red is decoration.
+- **Not verified at runtime.** No title in hand calls a converted method — they
+  are party beacons, leaderboard entries and workshop details. These rest on the
+  build gates, which is stated here rather than glossed.

--- a/src/shim/build.sh
+++ b/src/shim/build.sh
@@ -82,6 +82,12 @@ python3 check_overrides.py vtables.json overrides.json shim_pe.c
 python3 check_slot_transfer.py vtables.json steam_ifaces.h
 python3 gen_thunks.py vtables.json structs.json overrides.json gen
 
+# A converter that silently drops a field leaves the caller reading whatever
+# was in its buffer before the call — a plausible value, not an error. Checked
+# against Proton's field list rather than against the generated converter, so
+# the two would have to be wrong in the same way (ADR 0009).
+python3 check_convert.py structs.json gen
+
 # Every version a real title has been observed to ask for must have a real table.
 # This is the guard that would have caught Space Marine before it crashed: the
 # list is what titles NEED, vtables.json is what we HAVE, and a version in the

--- a/src/shim/check_convert.py
+++ b/src/shim/check_convert.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Prove the generated layout converters copy every field (ADR 0009).
+
+A converter for one of the few structs whose Windows and unix layouts genuinely
+differ is a field-by-field copy, generated from Proton's two field lists. The
+failure mode if it drops a field is the one this project keeps meeting: the call
+succeeds, the struct comes back, and one member holds whatever was in the
+caller's buffer beforehand. No error, a plausible value, and a title acting on
+it.
+
+So this does not read the generated converter. It reads Proton's field list from
+structs.json — the same source, independently — and emits a probe that:
+
+  fills the Windows-layout struct with pattern A
+  fills the destination with pattern B
+  runs w2u then u2w
+  compares EVERY field Proton declares
+
+A field the converter never copies keeps pattern B and is caught. That works
+precisely because the check derives its comparison from the declaration rather
+than from the converter, so the two would have to be wrong in the same way.
+
+Usage: check_convert.py <structs.json> <gen-dir>
+"""
+import json, os, re, subprocess, sys, tempfile
+
+
+def main():
+    structs = json.load(open(sys.argv[1]))
+    gendir = os.path.abspath(sys.argv[2])
+    conv = open(os.path.join(gendir, 'shim_gen_convert.h')).read()
+    names = sorted(set(re.findall(r'static void cvt_w2u_(\w+)\(', conv)))
+    if not names:
+        print('converters: none generated, nothing to check')
+        return
+
+    L = ['#include <cstdint>', '#include <cstdio>', '#include <cstring>',
+         '#include "gen/shim_gen_structs.h"', '#include "gen/shim_gen_convert.h"',
+         'static int bad;',
+         'static void chk(const char *s, const char *f, int ok)',
+         '{ if (!ok) { printf("  %s.%s NOT COPIED\\n", s, f); bad++; } }',
+         'int main(void) {']
+    nfields = 0
+    for n in names:
+        w, u = structs['structs']['w64_' + n], structs['structs']['u64_' + n]
+        L.append('  { struct w64_%s a, b; struct u64_%s m;' % (n, n))
+        L.append('    memset(&a, 0xA5, sizeof a); memset(&b, 0x3C, sizeof b);')
+        L.append('    memset(&m, 0x00, sizeof m);')
+        L.append('    cvt_w2u_%s(&a, &m); cvt_u2w_%s(&m, &b);' % (n, n))
+        for typ, fld, cnt in w['fields']:
+            nfields += 1
+            if cnt:
+                L.append('    chk("%s", "%s", !memcmp(a.%s, b.%s, sizeof a.%s));'
+                         % (n, fld, fld, fld, fld))
+            else:
+                L.append('    chk("%s", "%s", !memcmp(&a.%s, &b.%s, sizeof a.%s));'
+                         % (n, fld, fld, fld, fld))
+        L.append('  }')
+    L.append('  return bad; }')
+
+    d = tempfile.mkdtemp()
+    src = os.path.join(d, 'probe.cpp')
+    open(src, 'w').write('\n'.join(L) + '\n')
+    exe = os.path.join(d, 'probe')
+    inc = os.path.dirname(gendir)
+    r = subprocess.run(['clang++', '-std=c++17', '-I', inc, '-o', exe, src],
+                       capture_output=True, text=True)
+    if r.returncode:
+        print(r.stderr, file=sys.stderr)
+        sys.exit('converter probe did not compile')
+    r = subprocess.run([exe], capture_output=True, text=True)
+    sys.stdout.write(r.stdout)
+    if r.returncode:
+        sys.exit('layout converters DROP fields — see above. A dropped field '
+                 'leaves the caller reading whatever was in its buffer before '
+                 'the call, which is a plausible value and not an error.')
+    print('converters: %d structs, %d fields round-trip w64 -> u64 -> w64 intact'
+          % (len(names), nfields))
+
+
+main()

--- a/src/shim/check_overrides.py
+++ b/src/shim/check_overrides.py
@@ -60,7 +60,10 @@ def main():
             if iface(ver) != i:
                 continue
             for s in t['slots']:
-                if s['name'].startswith('GetISteam'):
+                n = s['name']
+                if n.startswith('DEPRECATED_'):
+                    n = n[11:]
+                if n.startswith('GetISteam'):
                     wired.add((i, s['name']))
 
     listed = {(o['interface'], o['method'])

--- a/src/shim/extract_structs.py
+++ b/src/shim/extract_structs.py
@@ -79,6 +79,37 @@ def strip_cxx(body):
     return '\n'.join(l for l in out if l.strip())
 
 
+ARRAY_RE = re.compile(r'^\s*[WU](?:64|32)_ARRAY\(\s*([\w ]+?)\s*,\s*(\d+)\s*,\s*(\w+)\s*\);\s*$', re.M)
+
+
+def resolve_array_macros(body):
+    """W64_ARRAY(char, 129, m_rgchTitle) -> `char m_rgchTitle[129];`, which is
+    the C expansion in steamclient_structs.h. The C++ expansion is a std::array
+    of the same layout; we emit plain C so both halves of the seam can include
+    the header."""
+    return ARRAY_RE.sub(lambda m: '    %s %s[%s];' % (m.group(1), m.group(3), m.group(2)), body)
+
+
+FIELD_RE = re.compile(r'^\s*([A-Za-z_][\w ]*?[\w*])\s+(\w+)\s*(?:\[(\d+)\])?;\s*$')
+
+
+def fields_of(body):
+    """The members, as (type, name, array count or 0). Proton's explicit
+    `__pad_N[]` members are dropped: they exist to pin the layout, and a
+    converter that copied them would be copying the difference it is there to
+    absorb."""
+    out = []
+    for line in body.split('\n'):
+        m = FIELD_RE.match(line)
+        if not m:
+            continue
+        name = m.group(2)
+        if name.startswith('__pad'):
+            continue
+        out.append([m.group(1).strip(), name, int(m.group(3) or 0)])
+    return out
+
+
 def resolve_ptr_macros(body):
     """W64_PTR(decl, name, type) -> decl, which is its x86_64 expansion verbatim
     (steamclient_structs.h: `#define W64_PTR( decl, name, type ) decl`). Only the
@@ -105,8 +136,8 @@ def main():
 
     structs, order = {}, []
     for pack, name, body in STRUCT_RE.findall(gen):
-        body = resolve_ptr_macros(strip_cxx(body))
-        structs[name] = {'pack': int(pack), 'body': body}
+        body = resolve_array_macros(resolve_ptr_macros(strip_cxx(body)))
+        structs[name] = {'pack': int(pack), 'body': body, 'fields': fields_of(body)}
         order.append(name)
 
     opaque = {}

--- a/src/shim/gen/REPORT.md
+++ b/src/shim/gen/REPORT.md
@@ -19,11 +19,11 @@ the first — `ISteamMatchmakingServers::RequestInternetServerList` is refused f
 | --- | --- |
 | interface versions | 212 |
 | vtable slots | 6555 |
-| slots wired to a generated thunk | 5191 |
-| — of those, x86_64 only | 110 |
-| distinct shapes emitted | 1143 |
-| — of those, x86_64 only | 22 |
-| methods refused | 163 |
+| slots wired to a generated thunk | 5218 |
+| — of those, x86_64 only | 137 |
+| distinct shapes emitted | 1152 |
+| — of those, x86_64 only | 31 |
+| methods refused | 157 |
 
 ## x86_64-only shapes
 
@@ -55,7 +55,7 @@ calls one, which is a named line rather than a wrong answer.
 | `ISteamInventory` | 40 | 0 | 0 |
 | `ISteamMasterServerUpdater` | 14 | 0 | 0 |
 | `ISteamMatchmaking` | 59 | 0 | 0 |
-| `ISteamMatchmakingServers` | 19 | 5 | 9 |
+| `ISteamMatchmakingServers` | 20 | 6 | 9 |
 | `ISteamMusic` | 9 | 0 | 0 |
 | `ISteamMusicRemote` | 32 | 0 | 0 |
 | `ISteamNetworking` | 34 | 0 | 0 |
@@ -65,15 +65,15 @@ calls one, which is a named line rather than a wrong answer.
 | `ISteamNetworkingSocketsSerialized` | 9 | 0 | 0 |
 | `ISteamNetworkingUtils` | 27 | 1 | 2 |
 | `ISteamParentalSettings` | 6 | 0 | 0 |
-| `ISteamParties` | 8 | 0 | 4 |
+| `ISteamParties` | 12 | 4 | 0 |
 | `ISteamRemotePlay` | 21 | 0 | 0 |
 | `ISteamRemoteStorage` | 43 | 10 | 24 |
 | `ISteamScreenshots` | 9 | 0 | 0 |
 | `ISteamTimeline` | 21 | 0 | 0 |
-| `ISteamUGC` | 107 | 3 | 1 |
+| `ISteamUGC` | 110 | 6 | 0 |
 | `ISteamUnifiedMessages` | 5 | 0 | 0 |
 | `ISteamUser` | 82 | 0 | 6 |
-| `ISteamUserStats` | 52 | 2 | 11 |
+| `ISteamUserStats` | 53 | 3 | 10 |
 | `ISteamUtils` | 27 | 0 | 18 |
 | `ISteamVideo` | 4 | 0 | 0 |
 
@@ -96,7 +96,7 @@ calls one, which is a named line rather than a wrong answer.
 | `ISteamClient` | `BReleaseSteamPipe` | 17 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamClient` | `ConnectToGlobalUser` | 17 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamClient` | `CreateSteamPipe` | 17 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
-| `ISteamClient` | `DEPRECATED_GetISteamUnifiedMessages` | 4 | returns `void *`, a native pointer — a 32-bit PE cannot hold a macOS heap address, and there is no length to copy down by |
+| `ISteamClient` | `DEPRECATED_GetISteamUnifiedMessages` | 4 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamClient` | `DEPRECATED_Remove_SteamAPI_CPostAPIResultInProcess` | 6 | function-pointer parameter `void (*)(void)` — calling it means a deferred upcall from native code back into PE code, which the seam does not carry |
 | `ISteamClient` | `DEPRECATED_Set_SteamAPI_CPostAPIResultInProcess` | 6 | function-pointer parameter `void (*)(void)` — calling it means a deferred upcall from native code back into PE code, which the seam does not carry |
 | `ISteamClient` | `GetISteamAppList` | 8 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
@@ -130,7 +130,7 @@ calls one, which is a named line rather than a wrong answer.
 | `ISteamClient` | `GetISteamUserStats` | 16 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamClient` | `GetISteamUtils` | 17 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamClient` | `GetISteamVideo` | 7 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
-| `ISteamClient` | `GetIVAC` | 1 | returns `void *`, a native pointer — a 32-bit PE cannot hold a macOS heap address, and there is no length to copy down by |
+| `ISteamClient` | `GetIVAC` | 1 | returns `void *`, a native pointer to a type Proton either states no layout for or states differs between the Windows and unix forms — so there is nothing the PE side could safely dereference, and no length to copy down by |
 | `ISteamClient` | `ReleaseUser` | 17 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamClient` | `Remove_SteamAPI_CPostAPIResultInProcess` | 1 | function-pointer parameter `void (*)(uint64_t, void *, uint32_t, int32_t)` — calling it means a deferred upcall from native code back into PE code, which the seam does not carry |
 | `ISteamClient` | `SetWarningMessageHook` | 16 | function-pointer parameter `void (*)(int32_t, const char *)` — calling it means a deferred upcall from native code back into PE code, which the seam does not carry |
@@ -159,7 +159,7 @@ calls one, which is a named line rather than a wrong answer.
 | `ISteamInput` | `RunFrame` | 5 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamInput` | `Shutdown` | 5 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamMatchmakingServers` | `CancelQuery` | 3 | Proton hand-writes this wrapper — there is no one-line typed signature to read |
-| `ISteamMatchmakingServers` | `GetServerDetails` | 3 | returns `gameserveritem_t_105 *`, a native pointer — a 32-bit PE cannot hold a macOS heap address, and there is no length to copy down by |
+| `ISteamMatchmakingServers` | `GetServerDetails` | 2 | Proton hand-writes this wrapper — there is no one-line typed signature to read |
 | `ISteamMatchmakingServers` | `ReleaseRequest` | 2 | Proton hand-writes this wrapper — there is no one-line typed signature to read |
 | `ISteamMatchmakingServers` | `RequestFavoritesServerList` | 2 | Proton hand-writes this wrapper — there is no one-line typed signature to read |
 | `ISteamMatchmakingServers` | `RequestFriendsServerList` | 2 | Proton hand-writes this wrapper — there is no one-line typed signature to read |
@@ -170,7 +170,7 @@ calls one, which is a named line rather than a wrong answer.
 | `ISteamNetworkingFakeUDPPort` | `DestroyFakeUDPPort` | 1 | Proton hand-writes this wrapper — there is no one-line typed signature to read |
 | `ISteamNetworkingFakeUDPPort` | `ReceiveMessages` | 1 | Proton hand-writes this wrapper — there is no one-line typed signature to read |
 | `ISteamNetworkingMessages` | `ReceiveMessagesOnChannel` | 1 | Proton hand-writes this wrapper — there is no one-line typed signature to read |
-| `ISteamNetworkingSockets` | `CreateFakeUDPPort` | 2 | returns `void *`, a native pointer — a 32-bit PE cannot hold a macOS heap address, and there is no length to copy down by |
+| `ISteamNetworkingSockets` | `CreateFakeUDPPort` | 2 | returns `void *`, a native pointer to a type Proton either states no layout for or states differs between the Windows and unix forms — so there is nothing the PE side could safely dereference, and no length to copy down by |
 | `ISteamNetworkingSockets` | `GetCertificateRequest` | 4 | function-pointer parameter `char (*)[1024]` — calling it means a deferred upcall from native code back into PE code, which the seam does not carry |
 | `ISteamNetworkingSockets` | `ReceiveMessagesOnConnection` | 7 | Proton hand-writes this wrapper — there is no one-line typed signature to read |
 | `ISteamNetworkingSockets` | `ReceiveMessagesOnListenSocket` | 3 | Proton hand-writes this wrapper — there is no one-line typed signature to read |
@@ -180,10 +180,6 @@ calls one, which is a named line rather than a wrong answer.
 | `ISteamNetworkingSockets` | `SetCertificate` | 4 | function-pointer parameter `char (*)[1024]` — calling it means a deferred upcall from native code back into PE code, which the seam does not carry |
 | `ISteamNetworkingUtils` | `AllocateMessage` | 2 | Proton hand-writes this wrapper — there is no one-line typed signature to read |
 | `ISteamNetworkingUtils` | `SetDebugOutputFunction` | 4 | function-pointer parameter `void (*)(uint32_t, const char *)` — calling it means a deferred upcall from native code back into PE code, which the seam does not carry |
-| `ISteamParties` | `CreateBeacon` | 1 | parameter points at `SteamPartyBeaconLocation_t`, whose Windows and unix layouts differ on x86_64 by Proton's own generated definitions — it needs a field-by-field converter, and the element count and direction are not in the signature |
-| `ISteamParties` | `GetAvailableBeaconLocations` | 1 | parameter points at `SteamPartyBeaconLocation_t`, whose Windows and unix layouts differ on x86_64 by Proton's own generated definitions — it needs a field-by-field converter, and the element count and direction are not in the signature |
-| `ISteamParties` | `GetBeaconDetails` | 1 | parameter points at `SteamPartyBeaconLocation_t`, whose Windows and unix layouts differ on x86_64 by Proton's own generated definitions — it needs a field-by-field converter, and the element count and direction are not in the signature |
-| `ISteamParties` | `GetBeaconLocationData` | 1 | by-value parameter `SteamPartyBeaconLocation_t`, whose Windows and unix layouts differ on x86_64 by Proton's own generated definitions |
 | `ISteamRemoteStorage` | `FileDelete` | 14 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamRemoteStorage` | `FileExists` | 15 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamRemoteStorage` | `FileForget` | 13 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
@@ -208,7 +204,6 @@ calls one, which is a named line rather than a wrong answer.
 | `ISteamRemoteStorage` | `IsCloudEnabledForApp` | 13 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamRemoteStorage` | `SetCloudEnabledForApp` | 13 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamRemoteStorage` | `SetSyncPlatforms` | 12 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
-| `ISteamUGC` | `GetQueryUGCResult` | 19 | parameter points at `SteamUGCDetails_t_126`, whose Windows and unix layouts differ on x86_64 by Proton's own generated definitions — it needs a field-by-field converter, and the element count and direction are not in the signature |
 | `ISteamUser` | `BLoggedOn` | 20 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamUser` | `GetEncryptedAppTicket` | 10 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamUser` | `GetHSteamUser` | 20 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
@@ -220,7 +215,6 @@ calls one, which is a named line rather than a wrong answer.
 | `ISteamUserStats` | `GetAchievementAndUnlockTime` | 7 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamUserStats` | `GetAchievementDisplayAttribute` | 13 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamUserStats` | `GetAchievementName` | 5 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
-| `ISteamUserStats` | `GetDownloadedLeaderboardEntry` | 3 | parameter points at `LeaderboardEntry_t_123`, whose Windows and unix layouts differ on x86_64 by Proton's own generated definitions — it needs a field-by-field converter, and the element count and direction are not in the signature |
 | `ISteamUserStats` | `GetNumAchievements` | 5 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamUserStats` | `RequestCurrentStats` | 12 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |
 | `ISteamUserStats` | `ResetAllStats` | 9 | hand-written: a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot |

--- a/src/shim/gen_thunks.py
+++ b/src/shim/gen_thunks.py
@@ -135,7 +135,7 @@ class Refuse(Exception):
     """Carries the reason verbatim into REPORT.md. There is no unnamed refusal."""
 
 
-def map_param(t):
+def map_param(t, spec=None):
     """C parameter type -> (field code, PE thunk type, native arg type, x64_only,
     by-value struct name or None).
 
@@ -154,31 +154,36 @@ def map_param(t):
         # array crosses verbatim; only a 32-bit PE, whose pointees are 4 bytes
         # wide, cannot be read in place. So this is an i386 problem that was
         # being charged to both bitnesses.
-        return 'Q', 'void *', 'void *', True, None
+        return 'Q', 'void *', 'void *', True, None, None
     if t.endswith('*') or t.endswith(']'):
         base, kind = struct_kind(re.sub(r'\[.*$', '', t))
         if kind == 'x64-differs':
+            if spec:
+                # Declared in overrides.json: direction and extent supplied, the
+                # conversion itself generated from Proton's two field lists.
+                return 'Q', 'void *', 'void *', True, None, dict(spec, struct=base)
             raise Refuse('parameter points at `%s`, whose Windows and unix layouts '
                          'differ on x86_64 by Proton\'s own generated definitions — '
-                         'it needs a field-by-field converter, and the element '
-                         'count and direction are not in the signature' % base)
+                         'the converter is mechanical but the direction and element '
+                         'count are not in the signature; declare them in '
+                         'overrides.json `marshal`' % base)
         if kind == 'x64-unknown':
             raise Refuse('parameter points at `%s`, for which Proton generates a '
                          'Windows layout but no unix counterpart, so nothing says '
                          'whether the two agree' % base)
         if kind == 'x64-identical':
             # Proton states the unix layout IS the Windows layout on x86_64.
-            return 'Q', 'void *', 'void *', True, None
+            return 'Q', 'void *', 'void *', True, None, None
         # plain, opaque, or a type Proton never splits: an address the GAME owns,
         # zero-extending into the uint64 field, read or written in place — the
         # same path GetUserDataFolder has taken since #20.
-        return 'Q', 'void *', 'void *', False, None
+        return 'Q', 'void *', 'void *', False, None, None
     bare = norm(t.replace('const', ''))
     if bare in ID_TYPES:
-        return 'Q', 'uint64_t', 'uint64_t', False, None
+        return 'Q', 'uint64_t', 'uint64_t', False, None, None
     if bare in SCALARS:
         c, pe, nat = SCALARS[bare]
-        return c, pe, nat, False, None
+        return c, pe, nat, False, None, None
     # A by-value aggregate. It crosses as the ADDRESS of the caller's copy, and
     # the native side passes it by value again on its own side — which needs the
     # type declared, so the type is emitted from Proton's own definition rather
@@ -186,13 +191,20 @@ def map_param(t):
     base, kind = struct_kind(bare)
     if kind in ('plain', 'opaque'):
         ct = struct_ctype(base, kind)
-        return 'Q', ct, ct, False, ct
+        return 'Q', ct, ct, False, ct, None
     if kind == 'x64-identical':
         ct = struct_ctype(base, kind)
-        return 'Q', ct, ct, True, ct
+        return 'Q', ct, ct, True, ct, None
     if kind == 'x64-differs':
+        if spec:
+            # By value: the seam carries the address of the caller's copy in the
+            # WINDOWS layout, and the native side is handed the converted UNIX
+            # one by value.
+            return ('Q', 'w64_' + base, 'u64_' + base, True, 'w64_' + base,
+                    dict(spec, struct=base, byval=True))
         raise Refuse('by-value parameter `%s`, whose Windows and unix layouts '
-                     'differ on x86_64 by Proton\'s own generated definitions' % base)
+                     'differ on x86_64; declare direction in overrides.json '
+                     '`marshal`' % base)
     raise Refuse('by-value aggregate parameter `%s` — Proton states no layout '
                  'for it' % t)
 
@@ -239,9 +251,19 @@ def map_ret(sig):
                              'layouts differ on x86_64' % b2)
             raise Refuse('returns the aggregate `%s` by value and Proton states '
                          'no layout for it' % base)
-        raise Refuse('returns `%s`, a native pointer — a 32-bit PE cannot hold '
-                     'a macOS heap address, and there is no length to copy down '
-                     'by' % r)
+        # A pointer to a struct whose layout both sides agree on. On x86_64 this
+        # is the same move `const char *` returns already make: one address
+        # space, so the PE dereferences the native object in place, and lifetime
+        # is Valve's documented "valid until the next call" either way. A 32-bit
+        # PE cannot hold the address at all, so this is x86_64-only.
+        b2, kind = struct_kind(base)
+        if kind in ('plain', 'opaque', 'x64-identical'):
+            ct = struct_ctype(b2, kind)
+            return 'ptr', 'Q', ct + ' *', 'void *', True, ct
+        raise Refuse('returns `%s`, a native pointer to a type Proton either '
+                     'states no layout for or states differs between the Windows '
+                     'and unix forms — so there is nothing the PE side could '
+                     'safely dereference, and no length to copy down by' % r)
     if r in ID_TYPES:
         return 'val', 'Q', 'uint64_t', 'uint64_t', False, None
     if r in SCALARS:
@@ -250,7 +272,7 @@ def map_ret(sig):
     raise Refuse('returns the by-value aggregate `%s`' % r)
 
 
-def shape_of(sig):
+def shape_of(sig, specs=None):
     """One signature -> the shape record, or Refuse. `codes` is the argument
     field-code string that names the params struct; `x64_only` is true if ANY
     part of the signature is correct on x86_64 but not on i386; `structs` is the
@@ -260,17 +282,26 @@ def shape_of(sig):
     codes, pe_args, nat_args, structs = '', [], [], set()
     if rstruct:
         structs.add(rstruct)
+    marshal = []
     for i, (t, name) in enumerate(args):
-        c, pe, nat, ax, st = map_param(t)
+        spec = (specs or {}).get(i)
+        if spec and spec['param'] != name:
+            raise Refuse('overrides.json declares marshalling for argument %d as '
+                         '`%s`, but this version calls it `%s` — the parameters '
+                         'were renamed or reordered' % (i, spec['param'], name))
+        c, pe, nat, ax, st, mr = map_param(t, spec)
         codes += c
         x64 = x64 or ax
         if st:
             structs.add(st)
+        if mr:
+            mr = dict(mr, index=i)
+            marshal.append(mr)
         pe_args.append((pe, 'a%d' % i, norm(t), name, st))
         nat_args.append((nat, st))
     return dict(kind=kind, codes=codes, rcode=rcode, pe_ret=pe_ret,
                 nat_ret=nat_ret, pe_args=pe_args, nat_args=nat_args,
-                x64_only=x64, structs=structs)
+                x64_only=x64, structs=structs, marshal=marshal)
 
 
 def struct_name(sh):
@@ -305,6 +336,11 @@ def main():
     tables = data['tables']
     ovr = json.load(open(ovr_path))
     skip = {(o['interface'], o['method']): o for o in ovr['skip']}
+    # Per-method marshalling facts the signature cannot carry: direction, and
+    # the extent of an array parameter. Declared, never inferred (ADR 0009).
+    marshal_specs = collections.defaultdict(dict)
+    for m in ovr.get('marshal', []):
+        marshal_specs[(m['interface'], m['method'])][m['arg']] = m
 
     # Interface for each version, straight from Proton's own tag.
     iface_of = {v: (t['tag'].split('_', 1)[0][3:] if t['tag'].startswith('win')
@@ -349,7 +385,7 @@ def main():
                        'callee-cleanup byte count is unknown', [ver])
                 continue
             try:
-                sh = shape_of(s['sig'])
+                sh = shape_of(s['sig'], marshal_specs.get(key))
             except Refuse as e:
                 refuse(iface, s['name'], str(e), [ver])
                 continue
@@ -388,8 +424,13 @@ def main():
     # definitions themselves reference. Emitted from Proton's own text, in
     # Proton's own order, so nothing here is a re-derivation of a layout.
     need = set()
+    convert = set()
     for g in groups.values():
         need |= g['shape']['structs']
+        for mr in g['shape']['marshal']:
+            convert.add(mr['struct'])
+            need.add('w64_' + mr['struct'])
+            need.add('u64_' + mr['struct'])
     seen_dep = set()
     while need - seen_dep:
         for n in list(need - seen_dep):
@@ -437,6 +478,36 @@ def main():
         L.append('};')
         L.append('#pragma pack( pop )')
     write(outdir, 'shim_gen_structs.h', L)
+
+    # -- layout converters, unix side only ------------------------------------
+    #
+    # Only for the families Proton states genuinely differ on x86_64. The copy is
+    # field-by-field BY NAME, from Proton's own two field lists, with the
+    # explicit `__pad_N[]` members dropped — those exist to pin the layout, and
+    # copying them would be copying the very difference the converter absorbs.
+    L = [banner, '#pragma once', '']
+    for b in sorted(convert):
+        w, u = STRUCTS['structs']['w64_' + b], STRUCTS['structs']['u64_' + b]
+        wf = {f[1]: f for f in w['fields']}
+        uf = {f[1]: f for f in u['fields']}
+        common = [f[1] for f in w['fields'] if f[1] in uf]
+        missing = [f[1] for f in w['fields'] if f[1] not in uf] + \
+                  [f[1] for f in u['fields'] if f[1] not in wf]
+        if missing:
+            sys.exit('%s: the Windows and unix field sets differ by name (%s). A '
+                     'field-by-field copy cannot be generated; the two layouts are '
+                     'not the same struct.' % (b, ', '.join(missing)))
+        for a, bb, an, bn in (('w64_', 'u64_', 'w', 'u'), ('u64_', 'w64_', 'u', 'w')):
+            L.append('static void cvt_%s2%s_%s(const struct %s%s *%s, struct %s%s *%s)'
+                     % (an, bn, b, a, b, an, bb, b, bn))
+            L.append('{')
+            for f in common:
+                if wf[f][2]:
+                    L.append('    memcpy(%s->%s, %s->%s, sizeof %s->%s);' % (bn, f, an, f, bn, f))
+                else:
+                    L.append('    %s->%s = %s->%s;' % (bn, f, an, f))
+            L.append('}')
+    write(outdir, 'shim_gen_convert.h', L)
 
     # -- params structs -------------------------------------------------------
     L = [banner, '#pragma once', '']
@@ -575,6 +646,8 @@ def pe_thunk(name, g):
         L.append('    return sret;')
     elif sh['kind'] == 'agg':
         L.append('    return sret;')
+    elif sh['kind'] == 'ptr':
+        L.append('    return (%s)(uintptr_t)p.ret;' % sh['pe_ret'])
     elif sh['kind'] == 'str':
         L.append('    return native_str(p.ret);')
     elif sh['kind'] == 'val':
@@ -588,6 +661,17 @@ def _agg(sh):
     return sh['nat_ret']
 
 
+def _marshal_back(sh):
+    """Copy any `out`/`inout` buffer back into the caller's Windows layout."""
+    L = []
+    for mr in sh['marshal']:
+        if mr['dir'] in ('out', 'inout'):
+            i, b = mr['index'], mr['struct']
+            L.append('    if (wv%d) for (size_t k = 0; k < cv%d.size(); k++) '
+                     'cvt_u2w_%s(&cv%d[k], &wv%d[k]);' % (i, i, b, i, i))
+    return L
+
+
 def unix_handler(name, g):
     """The unix half: index the native vtable with the slot the PE side sent and
     call through a typed function pointer. No class cast, so no transcription."""
@@ -596,8 +680,12 @@ def unix_handler(name, g):
     nat_ret = sh['nat_ret'] if sh['kind'] != 'agg' else sh['nat_ret']
     fnt = '%s (*)(void *%s)' % (nat_ret,
                                 ''.join(', ' + t for t, _s in sh['nat_args']))
+    converted = {mr['index']: mr for mr in sh['marshal']}
     call = ''
     for i, (t, bystruct) in enumerate(sh['nat_args']):
+        if i in converted:
+            call += (', *cv%d.data()' % i) if converted[i].get('byval') else (', cv%d.data()' % i)
+            continue
         if bystruct:
             call += ', *(%s *)(uintptr_t)p->a%d' % (t, i)
         elif t == 'void *':
@@ -613,18 +701,36 @@ def unix_handler(name, g):
     L.append('    auto fn = (%s)vslot(p->handle, p->slot);' % fnt)
     L.append('    if (!fn) { ulog("%s::%s: slot %%d unresolvable — call dropped", '
              'p->slot); return 0; }' % (g['iface'], g['method']))
+    for mr in sh['marshal']:
+        i, b = mr['index'], mr['struct']
+        cnt = ('(size_t)p->a%d' % mr['count_arg']) if 'count_arg' in mr else '1'
+        L.append('    /* %s: %s */' % (mr['param'], mr['why']))
+        L.append('    std::vector<struct u64_%s> cv%d(%s);' % (b, i, cnt))
+        L.append('    auto *wv%d = (struct w64_%s *)(uintptr_t)p->a%d;' % (i, b, i))
+        if mr['dir'] in ('in', 'inout'):
+            L.append('    if (wv%d) for (size_t k = 0; k < cv%d.size(); k++) '
+                     'cvt_w2u_%s(&wv%d[k], &cv%d[k]);' % (i, i, b, i, i))
+        else:
+            # A pure `out`: the caller's buffer is not required to hold anything
+            # meaningful yet, so it is not read. Zeroed so the native side never
+            # sees this side's stack.
+            L.append('    memset(cv%d.data(), 0, cv%d.size() * sizeof(struct u64_%s));'
+                     % (i, i, b))
     if sh['kind'] == 'agg':
         # The native side returns the aggregate BY VALUE. Letting the compiler
         # make that call from the declared type is the whole point: SysV
         # classification depends on the struct's size and field classes, and
         # `p->ret` is the caller's own buffer, forwarded by the PE half.
         L.append('    %s v = fn((void *)(uintptr_t)p->handle%s);' % (nat_ret, call))
+        L += _marshal_back(sh)
         L.append('    if (p->ret) memcpy((void *)(uintptr_t)p->ret, &v, sizeof v);')
     elif sh['kind'] == 'void':
         L.append('    fn((void *)(uintptr_t)p->handle%s);' % call)
+        L += _marshal_back(sh)
     else:
         L.append('    p->ret = (%s)fn((void *)(uintptr_t)p->handle%s);'
                  % (CODE_C[sh['rcode']], call))
+        L += _marshal_back(sh)
     L.append('    return 0;')
     L.append('}')
     return L

--- a/src/shim/overrides.json
+++ b/src/shim/overrides.json
@@ -114,6 +114,12 @@
   },
   {
    "interface": "ISteamClient",
+   "method": "DEPRECATED_GetISteamUnifiedMessages",
+   "reason": "hand-written",
+   "why": "a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot"
+  },
+  {
+   "interface": "ISteamClient",
    "method": "GetISteamAppList",
    "reason": "hand-written",
    "why": "a hand-written thunk in shim_pe.c already serves this method; generating a second one would race it into the same slot"
@@ -735,6 +741,84 @@
    "method": "SetWarningMessageHook",
    "reason": "semantic override",
    "why": "installs a PE callback the native client would call back INTO, which the seam does not carry \u2014 and deliberately not forwarded even so, for the same reason as IsOverlayEnabled: it is a semantic, not a marshalling, decision."
+  }
+ ],
+ "_marshal": [
+  "Per-method marshalling facts the SIGNATURE cannot carry (ADR 0009).",
+  "",
+  "A parameter pointing at a struct whose Windows and unix layouts genuinely differ",
+  "on x86_64 needs converting on the unix side. The conversion itself is mechanical --",
+  "Proton states both layouts field for field -- but two things are not derivable and",
+  "must be declared here or the generator refuses the method:",
+  "",
+  "  dir    in | out | inout. NOT derivable from const-ness: ISteamParties::CreateBeacon",
+  "         takes a NON-const pointer that is an INPUT (the location to create a beacon",
+  "         at), while the other five non-const cases are outputs. Converting an `out`",
+  "         inward would read uninitialised PE memory; skipping the outward conversion",
+  "         on an `in` would be harmless but skipping it on an `out` returns garbage.",
+  "",
+  "  count  how many elements the pointer addresses. Usually 1; where it is an ARRAY the",
+  "         extent lives in another parameter, named by count_arg.",
+  "",
+  "`arg` is the zero-based index among the arguments after `this`, and `param` is the",
+  "name it must have -- checked at generation time, so a version that renames or",
+  "reorders its parameters fails the build instead of marshalling the wrong one."
+ ],
+ "marshal": [
+  {
+   "interface": "ISteamParties",
+   "method": "CreateBeacon",
+   "arg": 1,
+   "param": "pBeaconLocation",
+   "dir": "in",
+   "count": 1,
+   "why": "the location the caller is asking to open a beacon at \u2014 an input, despite the non-const pointer"
+  },
+  {
+   "interface": "ISteamParties",
+   "method": "GetAvailableBeaconLocations",
+   "arg": 0,
+   "param": "pLocationList",
+   "dir": "out",
+   "count_arg": 1,
+   "count_param": "uMaxNumLocations",
+   "why": "fills a caller-supplied ARRAY; the extent is the second parameter, not the signature"
+  },
+  {
+   "interface": "ISteamParties",
+   "method": "GetBeaconDetails",
+   "arg": 2,
+   "param": "pLocation",
+   "dir": "out",
+   "count": 1,
+   "why": "one location, written back to the caller"
+  },
+  {
+   "interface": "ISteamParties",
+   "method": "GetBeaconLocationData",
+   "arg": 0,
+   "param": "BeaconLocation",
+   "dir": "in",
+   "count": 1,
+   "why": "passed BY VALUE \u2014 the seam carries the address of the caller's copy, which is read and never written"
+  },
+  {
+   "interface": "ISteamUserStats",
+   "method": "GetDownloadedLeaderboardEntry",
+   "arg": 2,
+   "param": "pLeaderboardEntry",
+   "dir": "out",
+   "count": 1,
+   "why": "one entry, written back to the caller"
+  },
+  {
+   "interface": "ISteamUGC",
+   "method": "GetQueryUGCResult",
+   "arg": 2,
+   "param": "pDetails",
+   "dir": "out",
+   "count": 1,
+   "why": "one details record, written back to the caller"
   }
  ]
 }

--- a/src/shim/shim_pe.c
+++ b/src/shim/shim_pe.c
@@ -296,7 +296,14 @@ static void wire_getters(const char *ver)
     if (!d) { dbg("shim: wire_getters: no table for %s", ver); return; }
     for (i = 0; d->methods[i].name; i++) {
         const struct vt_method *m = &d->methods[i];
-        if (strncmp(m->name, "GetISteam", 9)) continue;
+        const char *n = m->name;
+        /* Valve retired some getters in place rather than removing the slot, so
+         * the family is `GetISteam*` OR `DEPRECATED_GetISteam*`. Matching only
+         * the first left DEPRECATED_GetISteamUnifiedMessages returning NULL from
+         * a stub, which is indistinguishable from "no such interface" to a title
+         * that still asks for it (ADR 0009). */
+        if (!strncmp(n, "DEPRECATED_", 11)) n += 11;
+        if (strncmp(n, "GetISteam", 9)) continue;
         if (m->bytes == 16)      d->vtable[m->slot] = (const void *)ic_GetIface_UPV;
         else if (m->bytes == 12) d->vtable[m->slot] = (const void *)ic_GetIface_PV;
         else dbg("shim: %s.%s unexpected shape (%u bytes) — left stubbed",

--- a/src/shim/shim_unix.cpp
+++ b/src/shim/shim_unix.cpp
@@ -19,6 +19,7 @@
 #include <cstring>
 #include <cstdarg>
 #include <string>
+#include <vector>
 
 #include <dlfcn.h>
 #include <fcntl.h>
@@ -33,6 +34,11 @@
 
 #include "shim_abi.h"
 #include "steam_ifaces.h"
+
+/* Layout converters for the few Steamworks structs whose Windows and unix forms
+ * genuinely differ on x86_64 (#84). Unix-side only: the conversion happens here,
+ * where both layouts are in scope, and the PE half never sees a u64_ form. */
+#include "gen/shim_gen_convert.h"
 
 typedef int32_t NTSTATUS;
 typedef NTSTATUS (*unixlib_entry_t)(void *args);

--- a/src/shim/structs.json
+++ b/src/shim/structs.json
@@ -1054,2706 +1054,18077 @@
  "structs": {
   "ActiveBeaconsUpdated_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "AppDataChanged_t": {
    "body": "    uint32_t m_nAppID;\n    int8_t m_bBySteamUI;\n    int8_t m_bCDDBUpdate;\n    uint8_t __pad_6[2];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBySteamUI",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCDDBUpdate",
+     0
+    ]
+   ],
    "pack": 4
   },
   "AppProofOfPurchaseKeyResponse_t_118": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_nAppID;\n    char (m_rgchKey)[64];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "AppProofOfPurchaseKeyResponse_t_137": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_nAppID;\n    uint32_t m_cchKeyLength;\n    char (m_rgchKey)[240];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cchKeyLength",
+     0
+    ]
+   ],
    "pack": 4
   },
   "AppResumingFromSuspend_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "AssociateWithClanResult_t": {
    "body": "    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "AvailableBeaconLocationsUpdated_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "AvatarImageLoaded_t": {
    "body": "    CSteamID m_steamID;\n    int32_t m_iImage;\n    int32_t m_iWide;\n    int32_t m_iTall;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_iImage",
+     0
+    ],
+    [
+     "int32_t",
+     "m_iWide",
+     0
+    ],
+    [
+     "int32_t",
+     "m_iTall",
+     0
+    ]
+   ],
    "pack": 4
   },
   "BroadcastUploadStart_t_132x": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "BroadcastUploadStart_t_161": {
    "body": "    int8_t m_bIsRTMP;",
+   "fields": [
+    [
+     "int8_t",
+     "m_bIsRTMP",
+     0
+    ]
+   ],
    "pack": 1
   },
   "BroadcastUploadStop_t": {
    "body": "    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "CallbackPipeFailure_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "ChangeNumOpenSlotsCallback_t": {
    "body": "    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "CheckFileSignature_t": {
    "body": "    uint32_t m_eCheckFileSignature;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eCheckFileSignature",
+     0
+    ]
+   ],
    "pack": 4
   },
   "ClanOfficerListResponse_t": {
    "body": "    CSteamID m_steamIDClan;\n    int32_t m_cOfficers;\n    uint8_t m_bSuccess;\n    uint8_t __pad_13[3];",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDClan",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cOfficers",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bSuccess",
+     0
+    ]
+   ],
    "pack": 4
   },
   "ClientGameServerDeny_t": {
    "body": "    uint32_t m_uAppID;\n    uint32_t m_unGameServerIP;\n    uint16_t m_usGameServerPort;\n    uint16_t m_bSecure;\n    uint32_t m_uReason;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_uAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unGameServerIP",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_usGameServerPort",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_bSecure",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_uReason",
+     0
+    ]
+   ],
    "pack": 4
   },
   "ComputeNewPlayerCompatibilityResult_t_116x": {
    "body": "    uint32_t m_eResult;\n    int32_t m_cPlayersThatDontLikeCandidate;\n    int32_t m_cPlayersThatCandidateDoesntLike;\n    int32_t m_cClanPlayersThatDontLikeCandidate;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cPlayersThatDontLikeCandidate",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cPlayersThatCandidateDoesntLike",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cClanPlayersThatDontLikeCandidate",
+     0
+    ]
+   ],
    "pack": 4
   },
   "ComputeNewPlayerCompatibilityResult_t_119": {
    "body": "    uint32_t m_eResult;\n    int32_t m_cPlayersThatDontLikeCandidate;\n    int32_t m_cPlayersThatCandidateDoesntLike;\n    int32_t m_cClanPlayersThatDontLikeCandidate;\n    CSteamID m_SteamIDCandidate;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cPlayersThatDontLikeCandidate",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cPlayersThatCandidateDoesntLike",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cClanPlayersThatDontLikeCandidate",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_SteamIDCandidate",
+     0
+    ]
+   ],
    "pack": 4
   },
   "ControllerAnalogActionData_t": {
    "body": "    uint32_t eMode;\n    float x;\n    float y;\n    int8_t bActive;",
+   "fields": [
+    [
+     "uint32_t",
+     "eMode",
+     0
+    ],
+    [
+     "float",
+     "x",
+     0
+    ],
+    [
+     "float",
+     "y",
+     0
+    ],
+    [
+     "int8_t",
+     "bActive",
+     0
+    ]
+   ],
    "pack": 1
   },
   "ControllerDigitalActionData_t": {
    "body": "    int8_t bState;\n    int8_t bActive;",
+   "fields": [
+    [
+     "int8_t",
+     "bState",
+     0
+    ],
+    [
+     "int8_t",
+     "bActive",
+     0
+    ]
+   ],
    "pack": 1
   },
   "ControllerMotionData_t": {
    "body": "    float rotQuatX;\n    float rotQuatY;\n    float rotQuatZ;\n    float rotQuatW;\n    float posAccelX;\n    float posAccelY;\n    float posAccelZ;\n    float rotVelX;\n    float rotVelY;\n    float rotVelZ;",
+   "fields": [
+    [
+     "float",
+     "rotQuatX",
+     0
+    ],
+    [
+     "float",
+     "rotQuatY",
+     0
+    ],
+    [
+     "float",
+     "rotQuatZ",
+     0
+    ],
+    [
+     "float",
+     "rotQuatW",
+     0
+    ],
+    [
+     "float",
+     "posAccelX",
+     0
+    ],
+    [
+     "float",
+     "posAccelY",
+     0
+    ],
+    [
+     "float",
+     "posAccelZ",
+     0
+    ],
+    [
+     "float",
+     "rotVelX",
+     0
+    ],
+    [
+     "float",
+     "rotVelY",
+     0
+    ],
+    [
+     "float",
+     "rotVelZ",
+     0
+    ]
+   ],
    "pack": 1
   },
   "DlcInstalled_t": {
    "body": "    uint32_t m_nAppID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "DownloadClanActivityCountsResult_t": {
    "body": "    int8_t m_bSuccess;",
+   "fields": [
+    [
+     "int8_t",
+     "m_bSuccess",
+     0
+    ]
+   ],
    "pack": 1
   },
   "DurationControl_t_145": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_appid;\n    int8_t m_bApplicable;\n    uint8_t __pad_9[3];\n    int32_t m_csecsLast5h;\n    uint32_t m_progress;\n    uint32_t m_notification;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_appid",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bApplicable",
+     0
+    ],
+    [
+     "int32_t",
+     "m_csecsLast5h",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_progress",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_notification",
+     0
+    ]
+   ],
    "pack": 4
   },
   "DurationControl_t_147": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_appid;\n    int8_t m_bApplicable;\n    uint8_t __pad_9[3];\n    int32_t m_csecsLast5h;\n    uint32_t m_progress;\n    uint32_t m_notification;\n    int32_t m_csecsToday;\n    int32_t m_csecsRemaining;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_appid",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bApplicable",
+     0
+    ],
+    [
+     "int32_t",
+     "m_csecsLast5h",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_progress",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_notification",
+     0
+    ],
+    [
+     "int32_t",
+     "m_csecsToday",
+     0
+    ],
+    [
+     "int32_t",
+     "m_csecsRemaining",
+     0
+    ]
+   ],
    "pack": 4
   },
   "EncryptedAppTicketResponse_t": {
    "body": "    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "EquippedProfileItemsChanged_t": {
    "body": "    CSteamID m_steamID;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamID",
+     0
+    ]
+   ],
    "pack": 1
   },
   "EquippedProfileItems_t_154": {
    "body": "    uint32_t m_eResult;\n    CSteamID m_steamID;\n    int8_t m_bHasAnimatedAvatar;\n    int8_t m_bHasAvatarFrame;\n    int8_t m_bHasProfileModifier;\n    int8_t m_bHasProfileBackground;\n    int8_t m_bHasMiniProfileBackground;\n    uint8_t __pad_17[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamID",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bHasAnimatedAvatar",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bHasAvatarFrame",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bHasProfileModifier",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bHasProfileBackground",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bHasMiniProfileBackground",
+     0
+    ]
+   ],
    "pack": 4
   },
   "EquippedProfileItems_t_161": {
    "body": "    uint32_t m_eResult;\n    CSteamID m_steamID;\n    int8_t m_bHasAnimatedAvatar;\n    int8_t m_bHasAvatarFrame;\n    int8_t m_bHasProfileModifier;\n    int8_t m_bHasProfileBackground;\n    int8_t m_bHasMiniProfileBackground;\n    int8_t m_bFromCache;\n    uint8_t __pad_18[2];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamID",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bHasAnimatedAvatar",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bHasAvatarFrame",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bHasProfileModifier",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bHasProfileBackground",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bHasMiniProfileBackground",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bFromCache",
+     0
+    ]
+   ],
    "pack": 4
   },
   "FavoritesListAccountsUpdated_t": {
    "body": "    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "FavoritesListChanged_t_099u": {
    "body": "    uint32_t m_nIP;\n    uint32_t m_nQueryPort;\n    uint32_t m_nConnPort;\n    uint32_t m_nAppID;\n    uint32_t m_nFlags;\n    int8_t m_bAdd;\n    uint8_t __pad_21[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nIP",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nQueryPort",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConnPort",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nFlags",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAdd",
+     0
+    ]
+   ],
    "pack": 4
   },
   "FavoritesListChanged_t_128x": {
    "body": "    uint32_t m_nIP;\n    uint32_t m_nQueryPort;\n    uint32_t m_nConnPort;\n    uint32_t m_nAppID;\n    uint32_t m_nFlags;\n    int8_t m_bAdd;\n    uint8_t __pad_21[3];\n    uint32_t m_unAccountId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nIP",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nQueryPort",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConnPort",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nFlags",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAdd",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unAccountId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "FilterTextDictionaryChanged_t": {
    "body": "    int32_t m_eLanguage;",
+   "fields": [
+    [
+     "int32_t",
+     "m_eLanguage",
+     0
+    ]
+   ],
    "pack": 4
   },
   "FloatingGamepadTextInputDismissed_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "FriendGameInfo_t": {
    "body": "    CGameID m_gameID;\n    uint32_t m_unGameIP;\n    uint16_t m_usGamePort;\n    uint16_t m_usQueryPort;\n    CSteamID m_steamIDLobby;",
+   "fields": [
+    [
+     "CGameID",
+     "m_gameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unGameIP",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_usGamePort",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_usQueryPort",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamIDLobby",
+     0
+    ]
+   ],
    "pack": 4
   },
   "FriendRichPresenceUpdate_t": {
    "body": "    CSteamID m_steamIDFriend;\n    uint32_t m_nAppID;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDFriend",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "FriendSessionStateInfo_t": {
    "body": "    uint32_t m_uiOnlineSessionInstances;\n    uint8_t m_uiPublishedToFriendsSessionInstance;\n    uint8_t __pad_5[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_uiOnlineSessionInstances",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_uiPublishedToFriendsSessionInstance",
+     0
+    ]
+   ],
    "pack": 4
   },
   "FriendsEnumerateFollowingList_t": {
    "body": "    uint32_t m_eResult;\n    CSteamID (m_rgSteamID)[50];\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ]
+   ],
    "pack": 4
   },
   "FriendsGetFollowerCount_t": {
    "body": "    uint32_t m_eResult;\n    CSteamID m_steamID;\n    int32_t m_nCount;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nCount",
+     0
+    ]
+   ],
    "pack": 4
   },
   "FriendsIsFollowing_t": {
    "body": "    uint32_t m_eResult;\n    CSteamID m_steamID;\n    int8_t m_bIsFollowing;\n    uint8_t __pad_13[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamID",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bIsFollowing",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GCMessageAvailable_t": {
    "body": "    uint32_t m_nMessageSize;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nMessageSize",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GCMessageFailed_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "GSClientAchievementStatus_t": {
    "body": "    uint64_t m_SteamID;\n    char (m_pchAchievement)[128];\n    int8_t m_bUnlocked;\n    uint8_t __pad_137[7];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_SteamID",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUnlocked",
+     0
+    ]
+   ],
    "pack": 8
   },
   "GSClientApprove_t_099u": {
    "body": "    CSteamID m_SteamID;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_SteamID",
+     0
+    ]
+   ],
    "pack": 1
   },
   "GSClientApprove_t_126": {
    "body": "    CSteamID m_SteamID;\n    CSteamID m_OwnerSteamID;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_SteamID",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_OwnerSteamID",
+     0
+    ]
+   ],
    "pack": 1
   },
   "GSClientDeny_t": {
    "body": "    CSteamID m_SteamID;\n    uint32_t m_eDenyReason;\n    char (m_rgchOptionalText)[128];",
+   "fields": [
+    [
+     "CSteamID",
+     "m_SteamID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eDenyReason",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GSClientGroupStatus_t": {
    "body": "    CSteamID m_SteamIDUser;\n    CSteamID m_SteamIDGroup;\n    int8_t m_bMember;\n    int8_t m_bOfficer;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_SteamIDUser",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_SteamIDGroup",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bMember",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bOfficer",
+     0
+    ]
+   ],
    "pack": 1
   },
   "GSClientKick_t": {
    "body": "    CSteamID m_SteamID;\n    uint32_t m_eDenyReason;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_SteamID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eDenyReason",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GSGameplayStats_t": {
    "body": "    uint32_t m_eResult;\n    int32_t m_nRank;\n    uint32_t m_unTotalConnects;\n    uint32_t m_unTotalMinutesPlayed;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nRank",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unTotalConnects",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unTotalMinutesPlayed",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GSPolicyResponse_t": {
    "body": "    uint8_t m_bSecure;",
+   "fields": [
+    [
+     "uint8_t",
+     "m_bSecure",
+     0
+    ]
+   ],
    "pack": 1
   },
   "GSStatsReceived_t": {
    "body": "    uint32_t m_eResult;\n    CSteamID m_steamIDUser;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GSStatsStored_t": {
    "body": "    uint32_t m_eResult;\n    CSteamID m_steamIDUser;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GSStatsUnloaded_t": {
    "body": "    CSteamID m_steamIDUser;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ]
+   ],
    "pack": 1
   },
   "GameConnectedChatJoin_t": {
    "body": "    CSteamID m_steamIDClanChat;\n    CSteamID m_steamIDUser;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDClanChat",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ]
+   ],
    "pack": 1
   },
   "GameConnectedChatLeave_t": {
    "body": "    CSteamID m_steamIDClanChat;\n    CSteamID m_steamIDUser;\n    int8_t m_bKicked;\n    int8_t m_bDropped;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDClanChat",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bKicked",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bDropped",
+     0
+    ]
+   ],
    "pack": 1
   },
   "GameConnectedClanChatMsg_t": {
    "body": "    CSteamID m_steamIDClanChat;\n    CSteamID m_steamIDUser;\n    int32_t m_iMessageID;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDClanChat",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ],
+    [
+     "int32_t",
+     "m_iMessageID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GameConnectedFriendChatMsg_t": {
    "body": "    CSteamID m_steamIDUser;\n    int32_t m_iMessageID;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ],
+    [
+     "int32_t",
+     "m_iMessageID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GameLobbyJoinRequested_t": {
    "body": "    CSteamID m_steamIDLobby;\n    CSteamID m_steamIDFriend;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDLobby",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamIDFriend",
+     0
+    ]
+   ],
    "pack": 1
   },
   "GameOverlayActivated_t_099u": {
    "body": "    uint8_t m_bActive;",
+   "fields": [
+    [
+     "uint8_t",
+     "m_bActive",
+     0
+    ]
+   ],
    "pack": 1
   },
   "GameOverlayActivated_t_156": {
    "body": "    uint8_t m_bActive;\n    int8_t m_bUserInitiated;\n    uint8_t __pad_2[2];\n    uint32_t m_nAppID;",
+   "fields": [
+    [
+     "uint8_t",
+     "m_bActive",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserInitiated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GameOverlayActivated_t_158": {
    "body": "    uint8_t m_bActive;\n    int8_t m_bUserInitiated;\n    uint8_t __pad_2[2];\n    uint32_t m_nAppID;\n    uint32_t m_dwOverlayPID;",
+   "fields": [
+    [
+     "uint8_t",
+     "m_bActive",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserInitiated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_dwOverlayPID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GameRichPresenceJoinRequested_t": {
    "body": "    CSteamID m_steamIDFriend;\n    char (m_rgchConnect)[256];",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDFriend",
+     0
+    ]
+   ],
    "pack": 1
   },
   "GameServerChangeRequested_t": {
    "body": "    char (m_rgchServer)[64];\n    char (m_rgchPassword)[64];",
+   "fields": [],
    "pack": 1
   },
   "GameStatsSessionClosed_t": {
    "body": "    uint64_t m_ulSessionID;\n    uint32_t m_eResult;\n    uint8_t __pad_12[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSessionID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 8
   },
   "GameStatsSessionIssued_t": {
    "body": "    uint64_t m_ulSessionID;\n    uint32_t m_eResult;\n    int8_t m_bCollectingAny;\n    int8_t m_bCollectingDetails;\n    uint8_t __pad_14[2];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSessionID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCollectingAny",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCollectingDetails",
+     0
+    ]
+   ],
    "pack": 8
   },
   "GameWebCallback_t": {
    "body": "    char (m_szURL)[256];",
+   "fields": [],
    "pack": 1
   },
   "GamepadTextInputDismissed_t_121": {
    "body": "    int8_t m_bSubmitted;\n    uint8_t __pad_1[3];\n    uint32_t m_unSubmittedText;",
+   "fields": [
+    [
+     "int8_t",
+     "m_bSubmitted",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unSubmittedText",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GamepadTextInputDismissed_t_156": {
    "body": "    int8_t m_bSubmitted;\n    uint8_t __pad_1[3];\n    uint32_t m_unSubmittedText;\n    uint32_t m_unAppID;",
+   "fields": [
+    [
+     "int8_t",
+     "m_bSubmitted",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unSubmittedText",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GetAuthSessionTicketResponse_t": {
    "body": "    uint32_t m_hAuthTicket;\n    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hAuthTicket",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GetOPFSettingsResult_t": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_unVideoAppID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVideoAppID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GetTicketForWebApiResponse_t": {
    "body": "    uint32_t m_hAuthTicket;\n    uint32_t m_eResult;\n    int32_t m_cubTicket;\n    uint8_t (m_rgubTicket)[2560];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hAuthTicket",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cubTicket",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GetUserItemVoteResult_t": {
    "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    int8_t m_bVotedUp;\n    int8_t m_bVotedDown;\n    int8_t m_bVoteSkipped;\n    uint8_t __pad_15[1];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bVotedUp",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bVotedDown",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bVoteSkipped",
+     0
+    ]
+   ],
    "pack": 8
   },
   "GetVideoURLResult_t": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_unVideoAppID;\n    char (m_rgchURL)[256];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVideoAppID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "GlobalAchievementPercentagesReady_t": {
    "body": "    uint64_t m_nGameID;\n    uint32_t m_eResult;\n    uint8_t __pad_12[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 8
   },
   "GlobalStatsReceived_t": {
    "body": "    uint64_t m_nGameID;\n    uint32_t m_eResult;\n    uint8_t __pad_12[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 8
   },
   "HTML_BrowserReady_t": {
    "body": "    uint32_t unBrowserHandle;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "HTML_BrowserRestarted_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint32_t unOldBrowserHandle;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unOldBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "HTML_CanGoBackAndForward_t": {
    "body": "    uint32_t unBrowserHandle;\n    int8_t bCanGoBack;\n    int8_t bCanGoForward;\n    uint8_t __pad_6[2];",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "int8_t",
+     "bCanGoBack",
+     0
+    ],
+    [
+     "int8_t",
+     "bCanGoForward",
+     0
+    ]
+   ],
    "pack": 4
   },
   "HTML_CloseBrowser_t": {
    "body": "    uint32_t unBrowserHandle;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "HTML_HidePopup_t": {
    "body": "    uint32_t unBrowserHandle;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "HTML_HideToolTip_t": {
    "body": "    uint32_t unBrowserHandle;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "HTML_HorizontalScroll_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint32_t unScrollMax;\n    uint32_t unScrollCurrent;\n    float flPageScale;\n    int8_t bVisible;\n    uint8_t __pad_17[3];\n    uint32_t unPageSize;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unScrollMax",
+     0
+    ],
+    [
+     "uint32_t",
+     "unScrollCurrent",
+     0
+    ],
+    [
+     "float",
+     "flPageScale",
+     0
+    ],
+    [
+     "int8_t",
+     "bVisible",
+     0
+    ],
+    [
+     "uint32_t",
+     "unPageSize",
+     0
+    ]
+   ],
    "pack": 4
   },
   "HTML_SearchResults_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint32_t unResults;\n    uint32_t unCurrentMatch;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unResults",
+     0
+    ],
+    [
+     "uint32_t",
+     "unCurrentMatch",
+     0
+    ]
+   ],
    "pack": 4
   },
   "HTML_SetCursor_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint32_t eMouseCursor;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "eMouseCursor",
+     0
+    ]
+   ],
    "pack": 4
   },
   "HTML_ShowPopup_t": {
    "body": "    uint32_t unBrowserHandle;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "HTML_SizePopup_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint32_t unX;\n    uint32_t unY;\n    uint32_t unWide;\n    uint32_t unTall;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unY",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ]
+   ],
    "pack": 4
   },
   "HTML_VerticalScroll_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint32_t unScrollMax;\n    uint32_t unScrollCurrent;\n    float flPageScale;\n    int8_t bVisible;\n    uint8_t __pad_17[3];\n    uint32_t unPageSize;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unScrollMax",
+     0
+    ],
+    [
+     "uint32_t",
+     "unScrollCurrent",
+     0
+    ],
+    [
+     "float",
+     "flPageScale",
+     0
+    ],
+    [
+     "int8_t",
+     "bVisible",
+     0
+    ],
+    [
+     "uint32_t",
+     "unPageSize",
+     0
+    ]
+   ],
    "pack": 4
   },
   "IPCFailure_t": {
    "body": "    uint8_t m_eFailureType;",
+   "fields": [
+    [
+     "uint8_t",
+     "m_eFailureType",
+     0
+    ]
+   ],
    "pack": 1
   },
   "IPCountry_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "InputAnalogActionData_t": {
    "body": "    uint32_t eMode;\n    float x;\n    float y;\n    int8_t bActive;",
+   "fields": [
+    [
+     "uint32_t",
+     "eMode",
+     0
+    ],
+    [
+     "float",
+     "x",
+     0
+    ],
+    [
+     "float",
+     "y",
+     0
+    ],
+    [
+     "int8_t",
+     "bActive",
+     0
+    ]
+   ],
    "pack": 1
   },
   "InputDigitalActionData_t": {
    "body": "    int8_t bState;\n    int8_t bActive;",
+   "fields": [
+    [
+     "int8_t",
+     "bState",
+     0
+    ],
+    [
+     "int8_t",
+     "bActive",
+     0
+    ]
+   ],
    "pack": 1
   },
   "InputMotionDataV2_t": {
    "body": "    float driftCorrectedQuatX;\n    float driftCorrectedQuatY;\n    float driftCorrectedQuatZ;\n    float driftCorrectedQuatW;\n    float sensorFusionQuatX;\n    float sensorFusionQuatY;\n    float sensorFusionQuatZ;\n    float sensorFusionQuatW;\n    float deferredSensorFusionQuatX;\n    float deferredSensorFusionQuatY;\n    float deferredSensorFusionQuatZ;\n    float deferredSensorFusionQuatW;\n    float gravityX;\n    float gravityY;\n    float gravityZ;\n    float degreesPerSecondX;\n    float degreesPerSecondY;\n    float degreesPerSecondZ;",
+   "fields": [
+    [
+     "float",
+     "driftCorrectedQuatX",
+     0
+    ],
+    [
+     "float",
+     "driftCorrectedQuatY",
+     0
+    ],
+    [
+     "float",
+     "driftCorrectedQuatZ",
+     0
+    ],
+    [
+     "float",
+     "driftCorrectedQuatW",
+     0
+    ],
+    [
+     "float",
+     "sensorFusionQuatX",
+     0
+    ],
+    [
+     "float",
+     "sensorFusionQuatY",
+     0
+    ],
+    [
+     "float",
+     "sensorFusionQuatZ",
+     0
+    ],
+    [
+     "float",
+     "sensorFusionQuatW",
+     0
+    ],
+    [
+     "float",
+     "deferredSensorFusionQuatX",
+     0
+    ],
+    [
+     "float",
+     "deferredSensorFusionQuatY",
+     0
+    ],
+    [
+     "float",
+     "deferredSensorFusionQuatZ",
+     0
+    ],
+    [
+     "float",
+     "deferredSensorFusionQuatW",
+     0
+    ],
+    [
+     "float",
+     "gravityX",
+     0
+    ],
+    [
+     "float",
+     "gravityY",
+     0
+    ],
+    [
+     "float",
+     "gravityZ",
+     0
+    ],
+    [
+     "float",
+     "degreesPerSecondX",
+     0
+    ],
+    [
+     "float",
+     "degreesPerSecondY",
+     0
+    ],
+    [
+     "float",
+     "degreesPerSecondZ",
+     0
+    ]
+   ],
    "pack": 1
   },
   "InputMotionData_t": {
    "body": "    float rotQuatX;\n    float rotQuatY;\n    float rotQuatZ;\n    float rotQuatW;\n    float posAccelX;\n    float posAccelY;\n    float posAccelZ;\n    float rotVelX;\n    float rotVelY;\n    float rotVelZ;",
+   "fields": [
+    [
+     "float",
+     "rotQuatX",
+     0
+    ],
+    [
+     "float",
+     "rotQuatY",
+     0
+    ],
+    [
+     "float",
+     "rotQuatZ",
+     0
+    ],
+    [
+     "float",
+     "rotQuatW",
+     0
+    ],
+    [
+     "float",
+     "posAccelX",
+     0
+    ],
+    [
+     "float",
+     "posAccelY",
+     0
+    ],
+    [
+     "float",
+     "posAccelZ",
+     0
+    ],
+    [
+     "float",
+     "rotVelX",
+     0
+    ],
+    [
+     "float",
+     "rotVelY",
+     0
+    ],
+    [
+     "float",
+     "rotVelZ",
+     0
+    ]
+   ],
    "pack": 1
   },
   "JoinClanChatRoomCompletionResult_t": {
    "body": "    CSteamID m_steamIDClanChat;\n    uint32_t m_eChatRoomEnterResponse;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDClanChat",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eChatRoomEnterResponse",
+     0
+    ]
+   ],
    "pack": 4
   },
   "LeaderboardFindResult_t": {
    "body": "    uint64_t m_hSteamLeaderboard;\n    uint8_t m_bLeaderboardFound;\n    uint8_t __pad_9[7];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bLeaderboardFound",
+     0
+    ]
+   ],
    "pack": 8
   },
   "LeaderboardScoresDownloaded_t": {
    "body": "    uint64_t m_hSteamLeaderboard;\n    uint64_t m_hSteamLeaderboardEntries;\n    int32_t m_cEntryCount;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboardEntries",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cEntryCount",
+     0
+    ]
+   ],
    "pack": 8
   },
   "LicensesUpdated_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "LobbyChatMsg_t": {
    "body": "    uint64_t m_ulSteamIDLobby;\n    uint64_t m_ulSteamIDUser;\n    uint8_t m_eChatEntryType;\n    uint8_t __pad_17[3];\n    uint32_t m_iChatID;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDUser",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_eChatEntryType",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_iChatID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "LobbyChatUpdate_t": {
    "body": "    uint64_t m_ulSteamIDLobby;\n    uint64_t m_ulSteamIDUserChanged;\n    uint64_t m_ulSteamIDMakingChange;\n    uint32_t m_rgfChatMemberStateChange;\n    uint8_t __pad_28[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDUserChanged",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDMakingChange",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rgfChatMemberStateChange",
+     0
+    ]
+   ],
    "pack": 8
   },
   "LobbyClosing_t": {
    "body": "    uint64_t m_ulSteamIDLobby;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ]
+   ],
    "pack": 8
   },
   "LobbyDataUpdate_t_099u": {
    "body": "    uint64_t m_ulSteamIDLobby;\n    uint64_t m_ulSteamIDMember;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDMember",
+     0
+    ]
+   ],
    "pack": 8
   },
   "LobbyDataUpdate_t_111x": {
    "body": "    uint64_t m_ulSteamIDLobby;\n    uint64_t m_ulSteamIDMember;\n    uint8_t m_bSuccess;\n    uint8_t __pad_17[7];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDMember",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bSuccess",
+     0
+    ]
+   ],
    "pack": 8
   },
   "LobbyEnter_t": {
    "body": "    uint64_t m_ulSteamIDLobby;\n    uint32_t m_rgfChatPermissions;\n    int8_t m_bLocked;\n    uint8_t __pad_13[3];\n    uint32_t m_EChatRoomEnterResponse;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rgfChatPermissions",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bLocked",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_EChatRoomEnterResponse",
+     0
+    ]
+   ],
    "pack": 8
   },
   "LobbyGameCreated_t": {
    "body": "    uint64_t m_ulSteamIDLobby;\n    uint64_t m_ulSteamIDGameServer;\n    uint32_t m_unIP;\n    uint16_t m_usPort;\n    uint8_t __pad_22[2];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDGameServer",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unIP",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_usPort",
+     0
+    ]
+   ],
    "pack": 8
   },
   "LobbyInvite_t_099u": {
    "body": "    uint64_t m_ulSteamIDUser;\n    uint64_t m_ulSteamIDLobby;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSteamIDUser",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ]
+   ],
    "pack": 8
   },
   "LobbyInvite_t_112x": {
    "body": "    uint64_t m_ulSteamIDUser;\n    uint64_t m_ulSteamIDLobby;\n    uint64_t m_ulGameID;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSteamIDUser",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulGameID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "LobbyKicked_t_099u": {
    "body": "    uint64_t m_ulSteamIDLobby;\n    uint64_t m_ulSteamIDAdmin;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDAdmin",
+     0
+    ]
+   ],
    "pack": 8
   },
   "LobbyKicked_t_106": {
    "body": "    uint64_t m_ulSteamIDLobby;\n    uint64_t m_ulSteamIDAdmin;\n    uint8_t m_bKickedDueToDisconnect;\n    uint8_t __pad_17[7];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDAdmin",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bKickedDueToDisconnect",
+     0
+    ]
+   ],
    "pack": 8
   },
   "LobbyMatchList_t": {
    "body": "    uint32_t m_nLobbiesMatching;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nLobbiesMatching",
+     0
+    ]
+   ],
    "pack": 4
   },
   "LowBatteryPower_t": {
    "body": "    uint8_t m_nMinutesBatteryLeft;",
+   "fields": [
+    [
+     "uint8_t",
+     "m_nMinutesBatteryLeft",
+     0
+    ]
+   ],
    "pack": 1
   },
   "MarketEligibilityResponse_t": {
    "body": "    int8_t m_bAllowed;\n    uint8_t __pad_1[3];\n    uint32_t m_eNotAllowedReason;\n    uint32_t m_rtAllowedAtTime;\n    int32_t m_cdaySteamGuardRequiredDays;\n    int32_t m_cdayNewDeviceCooldown;",
+   "fields": [
+    [
+     "int8_t",
+     "m_bAllowed",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eNotAllowedReason",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtAllowedAtTime",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cdaySteamGuardRequiredDays",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cdayNewDeviceCooldown",
+     0
+    ]
+   ],
    "pack": 4
   },
   "MatchMakingKeyValuePair_t": {
    "body": "    char (m_szKey)[256];\n    char (m_szValue)[256];",
+   "fields": [],
    "pack": 1
   },
   "MusicPlayerRemoteToFront_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "MusicPlayerRemoteWillActivate_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "MusicPlayerRemoteWillDeactivate_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "MusicPlayerSelectsPlaylistEntry_t": {
    "body": "    int32_t nID;",
+   "fields": [
+    [
+     "int32_t",
+     "nID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "MusicPlayerSelectsQueueEntry_t": {
    "body": "    int32_t nID;",
+   "fields": [
+    [
+     "int32_t",
+     "nID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "MusicPlayerWantsLooped_t": {
    "body": "    int8_t m_bLooped;",
+   "fields": [
+    [
+     "int8_t",
+     "m_bLooped",
+     0
+    ]
+   ],
    "pack": 1
   },
   "MusicPlayerWantsPause_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "MusicPlayerWantsPlayNext_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "MusicPlayerWantsPlayPrevious_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "MusicPlayerWantsPlay_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "MusicPlayerWantsPlayingRepeatStatus_t": {
    "body": "    int32_t m_nPlayingRepeatStatus;",
+   "fields": [
+    [
+     "int32_t",
+     "m_nPlayingRepeatStatus",
+     0
+    ]
+   ],
    "pack": 4
   },
   "MusicPlayerWantsShuffled_t": {
    "body": "    int8_t m_bShuffled;",
+   "fields": [
+    [
+     "int8_t",
+     "m_bShuffled",
+     0
+    ]
+   ],
    "pack": 1
   },
   "MusicPlayerWantsVolume_t": {
    "body": "    float m_flNewVolume;",
+   "fields": [
+    [
+     "float",
+     "m_flNewVolume",
+     0
+    ]
+   ],
    "pack": 4
   },
   "MusicPlayerWillQuit_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "NameHistoryResponse_t": {
    "body": "    int32_t m_cSuccessfulLookups;\n    int32_t m_cFailedLookups;",
+   "fields": [
+    [
+     "int32_t",
+     "m_cSuccessfulLookups",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cFailedLookups",
+     0
+    ]
+   ],
    "pack": 4
   },
   "NewLaunchQueryParameters_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "NewUrlLaunchParameters_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "NumberOfCurrentPlayers_t": {
    "body": "    uint8_t m_bSuccess;\n    uint8_t __pad_1[3];\n    int32_t m_cPlayers;",
+   "fields": [
+    [
+     "uint8_t",
+     "m_bSuccess",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cPlayers",
+     0
+    ]
+   ],
    "pack": 4
   },
   "OverlayBrowserProtocolNavigation_t": {
    "body": "    char (rgchURI)[1024];",
+   "fields": [],
    "pack": 1
   },
   "P2PSessionConnectFail_t": {
    "body": "    CSteamID m_steamIDRemote;\n    uint8_t m_eP2PSessionError;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDRemote",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_eP2PSessionError",
+     0
+    ]
+   ],
    "pack": 1
   },
   "P2PSessionRequest_t": {
    "body": "    CSteamID m_steamIDRemote;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDRemote",
+     0
+    ]
+   ],
    "pack": 1
   },
   "P2PSessionState_t": {
    "body": "    uint8_t m_bConnectionActive;\n    uint8_t m_bConnecting;\n    uint8_t m_eP2PSessionError;\n    uint8_t m_bUsingRelay;\n    int32_t m_nBytesQueuedForSend;\n    int32_t m_nPacketsQueuedForSend;\n    uint32_t m_nRemoteIP;\n    uint16_t m_nRemotePort;\n    uint8_t __pad_18[2];",
+   "fields": [
+    [
+     "uint8_t",
+     "m_bConnectionActive",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bConnecting",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_eP2PSessionError",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bUsingRelay",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nBytesQueuedForSend",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPacketsQueuedForSend",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nRemoteIP",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_nRemotePort",
+     0
+    ]
+   ],
    "pack": 4
   },
   "PSNGameBootInviteResult_t": {
    "body": "    int8_t m_bGameBootInviteExists;\n    CSteamID m_steamIDLobby;",
+   "fields": [
+    [
+     "int8_t",
+     "m_bGameBootInviteExists",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamIDLobby",
+     0
+    ]
+   ],
    "pack": 1
   },
   "PersonaStateChange_t": {
    "body": "    uint64_t m_ulSteamID;\n    int32_t m_nChangeFlags;\n    uint8_t __pad_12[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSteamID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChangeFlags",
+     0
+    ]
+   ],
    "pack": 8
   },
   "PlaybackStatusHasChanged_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "RegisterActivationCodeResponse_t": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_unPackageRegistered;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unPackageRegistered",
+     0
+    ]
+   ],
    "pack": 4
   },
   "RemotePlayInputKey_t": {
    "body": "    int32_t m_eScancode;\n    uint32_t m_unModifiers;\n    uint32_t m_unKeycode;",
+   "fields": [
+    [
+     "int32_t",
+     "m_eScancode",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unModifiers",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unKeycode",
+     0
+    ]
+   ],
    "pack": 4
   },
   "RemotePlayInputMouseMotion_t": {
    "body": "    int8_t m_bAbsolute;\n    uint8_t __pad_1[3];\n    float m_flNormalizedX;\n    float m_flNormalizedY;\n    int32_t m_nDeltaX;\n    int32_t m_nDeltaY;",
+   "fields": [
+    [
+     "int8_t",
+     "m_bAbsolute",
+     0
+    ],
+    [
+     "float",
+     "m_flNormalizedX",
+     0
+    ],
+    [
+     "float",
+     "m_flNormalizedY",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nDeltaX",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nDeltaY",
+     0
+    ]
+   ],
    "pack": 4
   },
   "RemotePlayInputMouseWheel_t": {
    "body": "    uint32_t m_eDirection;\n    float m_flAmount;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eDirection",
+     0
+    ],
+    [
+     "float",
+     "m_flAmount",
+     0
+    ]
+   ],
    "pack": 4
   },
   "RemotePlayInput_t": {
    "body": "    uint32_t m_unSessionID;\n    uint32_t m_eType;\n    struct { uint8_t _[56]; } data;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unSessionID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eType",
+     0
+    ]
+   ],
    "pack": 4
   },
   "RemoteStorageAppSyncStatusCheck_t": {
    "body": "    uint32_t m_nAppID;\n    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "RemoteStorageAppSyncedClient_t": {
    "body": "    uint32_t m_nAppID;\n    uint32_t m_eResult;\n    int32_t m_unNumDownloads;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_unNumDownloads",
+     0
+    ]
+   ],
    "pack": 4
   },
   "RemoteStorageAppSyncedServer_t": {
    "body": "    uint32_t m_nAppID;\n    uint32_t m_eResult;\n    int32_t m_unNumUploads;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_unNumUploads",
+     0
+    ]
+   ],
    "pack": 4
   },
   "RemoteStorageConflictResolution_t": {
    "body": "    uint32_t m_nAppID;\n    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "RemoteStorageEnumeratePublishedFilesByUserActionResult_t": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_eAction;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t (m_rgPublishedFileId)[50];\n    uint32_t (m_rgRTimeUpdated)[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eAction",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ]
+   ],
    "pack": 8
   },
   "RemoteStorageFileReadAsyncComplete_t": {
    "body": "    uint64_t m_hFileReadAsync;\n    uint32_t m_eResult;\n    uint32_t m_nOffset;\n    uint32_t m_cubRead;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_hFileReadAsync",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nOffset",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cubRead",
+     0
+    ]
+   ],
    "pack": 8
   },
   "RemoteStorageFileWriteAsyncComplete_t": {
    "body": "    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "RemoteStorageLocalFileChange_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "RemoteStoragePublishFileProgress_t": {
    "body": "    double m_dPercentFile;\n    int8_t m_bPreview;\n    uint8_t __pad_9[7];",
+   "fields": [
+    [
+     "double",
+     "m_dPercentFile",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bPreview",
+     0
+    ]
+   ],
    "pack": 8
   },
   "RemoteStoragePublishedFileDeleted_t": {
    "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;\n    uint8_t __pad_12[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "RemoteStoragePublishedFileSubscribed_t": {
    "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;\n    uint8_t __pad_12[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "RemoteStoragePublishedFileUnsubscribed_t": {
    "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;\n    uint8_t __pad_12[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "RequestFriendsLobbiesResponse_t": {
    "body": "    uint64_t m_ulSteamIDFriend;\n    uint64_t m_ulSteamIDLobby;\n    int32_t m_cResultIndex;\n    int32_t m_cResultsTotal;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulSteamIDFriend",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cResultIndex",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cResultsTotal",
+     0
+    ]
+   ],
    "pack": 8
   },
   "ReservationNotificationCallback_t": {
    "body": "    uint64_t m_ulBeaconID;\n    CSteamID m_steamIDJoiner;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulBeaconID",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamIDJoiner",
+     0
+    ]
+   ],
    "pack": 8
   },
   "ScreenshotReady_t": {
    "body": "    uint32_t m_hLocal;\n    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hLocal",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "ScreenshotRequested_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "SearchForGameProgressCallback_t": {
    "body": "    uint64_t m_ullSearchID;\n    uint32_t m_eResult;\n    CSteamID m_lobbyID;\n    CSteamID m_steamIDEndedSearch;\n    int32_t m_nSecondsRemainingEstimate;\n    int32_t m_cPlayersSearching;\n    uint8_t __pad_36[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ullSearchID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_lobbyID",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamIDEndedSearch",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSecondsRemainingEstimate",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cPlayersSearching",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SearchForGameResultCallback_t": {
    "body": "    uint64_t m_ullSearchID;\n    uint32_t m_eResult;\n    int32_t m_nCountPlayersInGame;\n    int32_t m_nCountAcceptedGame;\n    CSteamID m_steamIDHost;\n    int8_t m_bFinalCallback;\n    uint8_t __pad_29[3];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ullSearchID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nCountPlayersInGame",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nCountAcceptedGame",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamIDHost",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bFinalCallback",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SetPersonaNameResponse_t": {
    "body": "    int8_t m_bSuccess;\n    int8_t m_bLocalSuccess;\n    uint8_t __pad_2[2];\n    uint32_t m_result;",
+   "fields": [
+    [
+     "int8_t",
+     "m_bSuccess",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bLocalSuccess",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_result",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SetUserItemVoteResult_t": {
    "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    int8_t m_bVoteUp;\n    uint8_t __pad_13[3];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bVoteUp",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SocketStatusCallback_t": {
    "body": "    uint32_t m_hSocket;\n    uint32_t m_hListenSocket;\n    CSteamID m_steamIDRemote;\n    int32_t m_eSNetSocketState;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hSocket",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_hListenSocket",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamIDRemote",
+     0
+    ],
+    [
+     "int32_t",
+     "m_eSNetSocketState",
+     0
+    ]
+   ],
    "pack": 4
   },
   "StartPlaytimeTrackingResult_t": {
    "body": "    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamAPICallCompleted_t_102x": {
    "body": "    uint64_t m_hAsyncCall;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_hAsyncCall",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamAPICallCompleted_t_137": {
    "body": "    uint64_t m_hAsyncCall;\n    int32_t m_iCallback;\n    uint32_t m_cubParam;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_hAsyncCall",
+     0
+    ],
+    [
+     "int32_t",
+     "m_iCallback",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cubParam",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamAppInstalled_t_128x": {
    "body": "    uint32_t m_nAppID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamAppInstalled_t_152": {
    "body": "    uint32_t m_nAppID;\n    int32_t m_iInstallFolderIndex;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_iInstallFolderIndex",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamAppUninstalled_t_128x": {
    "body": "    uint32_t m_nAppID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamAppUninstalled_t_152": {
    "body": "    uint32_t m_nAppID;\n    int32_t m_iInstallFolderIndex;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_iInstallFolderIndex",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamCallback_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "SteamControllerState001_t": {
    "body": "    uint32_t unPacketNum;\n    uint64_t ulButtons;\n    int16_t sLeftPadX;\n    int16_t sLeftPadY;\n    int16_t sRightPadX;\n    int16_t sRightPadY;",
+   "fields": [
+    [
+     "uint32_t",
+     "unPacketNum",
+     0
+    ],
+    [
+     "uint64_t",
+     "ulButtons",
+     0
+    ],
+    [
+     "int16_t",
+     "sLeftPadX",
+     0
+    ],
+    [
+     "int16_t",
+     "sLeftPadY",
+     0
+    ],
+    [
+     "int16_t",
+     "sRightPadX",
+     0
+    ],
+    [
+     "int16_t",
+     "sRightPadY",
+     0
+    ]
+   ],
    "pack": 1
   },
   "SteamControllerState_t": {
    "body": "    uint32_t unPacketNum;\n    uint64_t ulButtons;\n    int16_t sLeftPadX;\n    int16_t sLeftPadY;\n    int16_t sRightPadX;\n    int16_t sRightPadY;",
+   "fields": [
+    [
+     "uint32_t",
+     "unPacketNum",
+     0
+    ],
+    [
+     "uint64_t",
+     "ulButtons",
+     0
+    ],
+    [
+     "int16_t",
+     "sLeftPadX",
+     0
+    ],
+    [
+     "int16_t",
+     "sLeftPadY",
+     0
+    ],
+    [
+     "int16_t",
+     "sRightPadX",
+     0
+    ],
+    [
+     "int16_t",
+     "sRightPadY",
+     0
+    ]
+   ],
    "pack": 1
   },
   "SteamInputActionEvent_t": {
    "body": "    uint64_t controllerHandle;\n    uint32_t eEventType;\n    struct { uint8_t _[21]; } x;",
+   "fields": [
+    [
+     "uint64_t",
+     "controllerHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "eEventType",
+     0
+    ]
+   ],
    "pack": 1
   },
   "SteamInputDeviceConnected_t": {
    "body": "    uint64_t m_ulConnectedDeviceHandle;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulConnectedDeviceHandle",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamInputDeviceDisconnected_t": {
    "body": "    uint64_t m_ulDisconnectedDeviceHandle;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulDisconnectedDeviceHandle",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamInventoryDefinitionUpdate_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "SteamInventoryEligiblePromoItemDefIDs_t": {
    "body": "    uint32_t m_result;\n    CSteamID m_steamID;\n    int32_t m_numEligiblePromoItemDefs;\n    int8_t m_bCachedData;\n    uint8_t __pad_17[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_result",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_numEligiblePromoItemDefs",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamInventoryFullUpdate_t": {
    "body": "    int32_t m_handle;",
+   "fields": [
+    [
+     "int32_t",
+     "m_handle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamInventoryRequestPricesResult_t": {
    "body": "    uint32_t m_result;\n    char (m_rgchCurrency)[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_result",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamInventoryResultReady_t": {
    "body": "    int32_t m_handle;\n    uint32_t m_result;",
+   "fields": [
+    [
+     "int32_t",
+     "m_handle",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_result",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamItemDetails_t": {
    "body": "    uint64_t m_itemId;\n    int32_t m_iDefinition;\n    uint16_t m_unQuantity;\n    uint16_t m_unFlags;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_itemId",
+     0
+    ],
+    [
+     "int32_t",
+     "m_iDefinition",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_unQuantity",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_unFlags",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamNetAuthenticationStatus_t": {
    "body": "    uint32_t m_eAvail;\n    char (m_debugMsg)[256];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eAvail",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamNetConnectionInfo_t_144": {
    "body": "    SteamNetworkingIdentity_144 m_identityRemote;\n    int64_t m_nUserData;\n    uint32_t m_hListenSocket;\n    SteamNetworkingIPAddr m_addrRemote;\n    uint16_t m__pad1;\n    uint32_t m_idPOPRemote;\n    uint32_t m_idPOPRelay;\n    uint32_t m_eState;\n    int32_t m_eEndReason;\n    char (m_szEndDebug)[128];\n    char (m_szConnectionDescription)[128];\n    uint32_t (reserved)[64];",
+   "fields": [
+    [
+     "SteamNetworkingIdentity_144",
+     "m_identityRemote",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_hListenSocket",
+     0
+    ],
+    [
+     "SteamNetworkingIPAddr",
+     "m_addrRemote",
+     0
+    ],
+    [
+     "uint16_t",
+     "m__pad1",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_idPOPRemote",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_idPOPRelay",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eState",
+     0
+    ],
+    [
+     "int32_t",
+     "m_eEndReason",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamNetConnectionInfo_t_151": {
    "body": "    SteamNetworkingIdentity_151 m_identityRemote;\n    int64_t m_nUserData;\n    uint32_t m_hListenSocket;\n    SteamNetworkingIPAddr m_addrRemote;\n    uint16_t m__pad1;\n    uint32_t m_idPOPRemote;\n    uint32_t m_idPOPRelay;\n    uint32_t m_eState;\n    int32_t m_eEndReason;\n    char (m_szEndDebug)[128];\n    char (m_szConnectionDescription)[128];\n    uint32_t (reserved)[64];",
+   "fields": [
+    [
+     "SteamNetworkingIdentity_151",
+     "m_identityRemote",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_hListenSocket",
+     0
+    ],
+    [
+     "SteamNetworkingIPAddr",
+     "m_addrRemote",
+     0
+    ],
+    [
+     "uint16_t",
+     "m__pad1",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_idPOPRemote",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_idPOPRelay",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eState",
+     0
+    ],
+    [
+     "int32_t",
+     "m_eEndReason",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamNetConnectionInfo_t_153a": {
    "body": "    SteamNetworkingIdentity_144 m_identityRemote;\n    int64_t m_nUserData;\n    uint32_t m_hListenSocket;\n    SteamNetworkingIPAddr m_addrRemote;\n    uint16_t m__pad1;\n    uint32_t m_idPOPRemote;\n    uint32_t m_idPOPRelay;\n    uint32_t m_eState;\n    int32_t m_eEndReason;\n    char (m_szEndDebug)[128];\n    char (m_szConnectionDescription)[128];\n    int32_t m_nFlags;\n    uint32_t (reserved)[63];",
+   "fields": [
+    [
+     "SteamNetworkingIdentity_144",
+     "m_identityRemote",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_hListenSocket",
+     0
+    ],
+    [
+     "SteamNetworkingIPAddr",
+     "m_addrRemote",
+     0
+    ],
+    [
+     "uint16_t",
+     "m__pad1",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_idPOPRemote",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_idPOPRelay",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eState",
+     0
+    ],
+    [
+     "int32_t",
+     "m_eEndReason",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nFlags",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamNetConnectionRealTimeLaneStatus_t": {
    "body": "    int32_t m_cbPendingUnreliable;\n    int32_t m_cbPendingReliable;\n    int32_t m_cbSentUnackedReliable;\n    int32_t _reservePad1;\n    int64_t m_usecQueueTime;\n    uint32_t (reserved)[10];",
+   "fields": [
+    [
+     "int32_t",
+     "m_cbPendingUnreliable",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cbPendingReliable",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cbSentUnackedReliable",
+     0
+    ],
+    [
+     "int32_t",
+     "_reservePad1",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecQueueTime",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamNetConnectionRealTimeStatus_t_153a": {
    "body": "    uint32_t m_eState;\n    int32_t m_nPing;\n    float m_flConnectionQualityLocal;\n    float m_flConnectionQualityRemote;\n    float m_flOutPacketsPerSec;\n    float m_flOutBytesPerSec;\n    float m_flInPacketsPerSec;\n    float m_flInBytesPerSec;\n    int32_t m_nSendRateBytesPerSecond;\n    int32_t m_cbPendingUnreliable;\n    int32_t m_cbPendingReliable;\n    int32_t m_cbSentUnackedReliable;\n    int64_t m_usecQueueTime;\n    uint32_t (reserved)[16];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eState",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPing",
+     0
+    ],
+    [
+     "float",
+     "m_flConnectionQualityLocal",
+     0
+    ],
+    [
+     "float",
+     "m_flConnectionQualityRemote",
+     0
+    ],
+    [
+     "float",
+     "m_flOutPacketsPerSec",
+     0
+    ],
+    [
+     "float",
+     "m_flOutBytesPerSec",
+     0
+    ],
+    [
+     "float",
+     "m_flInPacketsPerSec",
+     0
+    ],
+    [
+     "float",
+     "m_flInBytesPerSec",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSendRateBytesPerSecond",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cbPendingUnreliable",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cbPendingReliable",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cbSentUnackedReliable",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecQueueTime",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamNetConnectionRealTimeStatus_t_164": {
    "body": "    uint32_t m_eState;\n    int32_t m_nPing;\n    float m_flConnectionQualityLocal;\n    float m_flConnectionQualityRemote;\n    float m_flOutPacketsPerSec;\n    float m_flOutBytesPerSec;\n    float m_flInPacketsPerSec;\n    float m_flInBytesPerSec;\n    int32_t m_nSendRateBytesPerSecond;\n    int32_t m_cbPendingUnreliable;\n    int32_t m_cbPendingReliable;\n    int32_t m_cbSentUnackedReliable;\n    int64_t m_usecQueueTime;\n    int32_t m_usecMaxJitter;\n    uint32_t (reserved)[15];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eState",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPing",
+     0
+    ],
+    [
+     "float",
+     "m_flConnectionQualityLocal",
+     0
+    ],
+    [
+     "float",
+     "m_flConnectionQualityRemote",
+     0
+    ],
+    [
+     "float",
+     "m_flOutPacketsPerSec",
+     0
+    ],
+    [
+     "float",
+     "m_flOutBytesPerSec",
+     0
+    ],
+    [
+     "float",
+     "m_flInPacketsPerSec",
+     0
+    ],
+    [
+     "float",
+     "m_flInBytesPerSec",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSendRateBytesPerSecond",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cbPendingUnreliable",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cbPendingReliable",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cbSentUnackedReliable",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecQueueTime",
+     0
+    ],
+    [
+     "int32_t",
+     "m_usecMaxJitter",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamNetworkPingLocation_t": {
    "body": "    uint8_t (m_data)[512];",
+   "fields": [],
    "pack": 1
   },
   "SteamNetworkingConfigValue_t": {
    "body": "    uint32_t m_eValue;\n    uint32_t m_eDataType;\n    struct { uint8_t _[8]; } m_val;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eValue",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eDataType",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamNetworkingFakeIPResult_t": {
    "body": "    uint32_t m_eResult;\n    SteamNetworkingIdentity_144 m_identity;\n    uint32_t m_unIP;\n    uint16_t (m_unPorts)[8];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_144",
+     "m_identity",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unIP",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamNetworkingIPAddr": {
    "body": "    struct { uint8_t _[16]; } data;\n    uint16_t m_port;",
+   "fields": [
+    [
+     "uint16_t",
+     "m_port",
+     0
+    ]
+   ],
    "pack": 1
   },
   "SteamNetworkingIdentity_144": {
    "body": "    uint32_t m_eType;\n    int32_t m_cbSize;\n    struct { uint8_t _[128]; } data;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eType",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cbSize",
+     0
+    ]
+   ],
    "pack": 1
   },
   "SteamNetworkingIdentity_151": {
    "body": "    uint32_t m_eType;\n    int32_t m_cbSize;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eType",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cbSize",
+     0
+    ]
+   ],
    "pack": 1
   },
   "SteamNetworkingMessagesSessionFailed_t_150": {
    "body": "    SteamNetConnectionInfo_t_144 m_info;",
+   "fields": [
+    [
+     "SteamNetConnectionInfo_t_144",
+     "m_info",
+     0
+    ]
+   ],
    "pack": 1
   },
   "SteamNetworkingMessagesSessionFailed_t_151": {
    "body": "    SteamNetConnectionInfo_t_151 m_info;",
+   "fields": [
+    [
+     "SteamNetConnectionInfo_t_151",
+     "m_info",
+     0
+    ]
+   ],
    "pack": 1
   },
   "SteamNetworkingMessagesSessionFailed_t_153a": {
    "body": "    SteamNetConnectionInfo_t_153a m_info;",
+   "fields": [
+    [
+     "SteamNetConnectionInfo_t_153a",
+     "m_info",
+     0
+    ]
+   ],
    "pack": 1
   },
   "SteamNetworkingMessagesSessionRequest_t_150": {
    "body": "    SteamNetworkingIdentity_144 m_identityRemote;",
+   "fields": [
+    [
+     "SteamNetworkingIdentity_144",
+     "m_identityRemote",
+     0
+    ]
+   ],
    "pack": 1
   },
   "SteamNetworkingMessagesSessionRequest_t_151": {
    "body": "    SteamNetworkingIdentity_151 m_identityRemote;",
+   "fields": [
+    [
+     "SteamNetworkingIdentity_151",
+     "m_identityRemote",
+     0
+    ]
+   ],
    "pack": 1
   },
   "SteamNetworkingPOPIDRender": {
    "body": "    char (buf)[8];",
+   "fields": [],
    "pack": 1
   },
   "SteamNetworkingQuickConnectionStatus": {
    "body": "    uint32_t m_eState;\n    int32_t m_nPing;\n    float m_flConnectionQualityLocal;\n    float m_flConnectionQualityRemote;\n    float m_flOutPacketsPerSec;\n    float m_flOutBytesPerSec;\n    float m_flInPacketsPerSec;\n    float m_flInBytesPerSec;\n    int32_t m_nSendRateBytesPerSecond;\n    int32_t m_cbPendingUnreliable;\n    int32_t m_cbPendingReliable;\n    int32_t m_cbSentUnackedReliable;\n    int64_t m_usecQueueTime;\n    uint32_t (reserved)[16];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eState",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPing",
+     0
+    ],
+    [
+     "float",
+     "m_flConnectionQualityLocal",
+     0
+    ],
+    [
+     "float",
+     "m_flConnectionQualityRemote",
+     0
+    ],
+    [
+     "float",
+     "m_flOutPacketsPerSec",
+     0
+    ],
+    [
+     "float",
+     "m_flOutBytesPerSec",
+     0
+    ],
+    [
+     "float",
+     "m_flInPacketsPerSec",
+     0
+    ],
+    [
+     "float",
+     "m_flInBytesPerSec",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSendRateBytesPerSecond",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cbPendingUnreliable",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cbPendingReliable",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cbSentUnackedReliable",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecQueueTime",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamParentalSettingsChanged_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "SteamRelayNetworkStatus_t": {
    "body": "    uint32_t m_eAvail;\n    int32_t m_bPingMeasurementInProgress;\n    uint32_t m_eAvailNetworkConfig;\n    uint32_t m_eAvailAnyRelay;\n    char (m_debugMsg)[256];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eAvail",
+     0
+    ],
+    [
+     "int32_t",
+     "m_bPingMeasurementInProgress",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eAvailNetworkConfig",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eAvailAnyRelay",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamRemotePlaySessionAvatarLoaded_t": {
    "body": "    uint32_t m_unSessionID;\n    int32_t m_iImage;\n    int32_t m_iWide;\n    int32_t m_iTall;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unSessionID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_iImage",
+     0
+    ],
+    [
+     "int32_t",
+     "m_iWide",
+     0
+    ],
+    [
+     "int32_t",
+     "m_iTall",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamRemotePlaySessionConnected_t": {
    "body": "    uint32_t m_unSessionID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unSessionID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamRemotePlaySessionDisconnected_t": {
    "body": "    uint32_t m_unSessionID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unSessionID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamRemotePlayTogetherGuestInvite_t": {
    "body": "    char (m_szConnectURL)[1024];",
+   "fields": [],
    "pack": 1
   },
   "SteamServerConnectFailure_t_099u": {
    "body": "    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamServerConnectFailure_t_135": {
    "body": "    uint32_t m_eResult;\n    int8_t m_bStillRetrying;\n    uint8_t __pad_5[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bStillRetrying",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamServersConnected_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "SteamServersDisconnected_t": {
    "body": "    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SteamShutdown_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "SteamTimelineEventRecordingExists_t": {
    "body": "    uint64_t m_ulEventID;\n    int8_t m_bRecordingExists;\n    uint8_t __pad_9[7];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulEventID",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bRecordingExists",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamTimelineGamePhaseRecordingExists_t": {
    "body": "    char (m_rgchPhaseID)[64];\n    uint64_t m_ulRecordingMS;\n    uint64_t m_ulLongestClipMS;\n    uint32_t m_unClipCount;\n    uint32_t m_unScreenshotCount;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_ulRecordingMS",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulLongestClipMS",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unClipCount",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unScreenshotCount",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamUGCQueryCompleted_t_126": {
    "body": "    uint64_t m_handle;\n    uint32_t m_eResult;\n    uint32_t m_unNumResultsReturned;\n    uint32_t m_unTotalMatchingResults;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_handle",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unNumResultsReturned",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unTotalMatchingResults",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamUGCQueryCompleted_t_128x": {
    "body": "    uint64_t m_handle;\n    uint32_t m_eResult;\n    uint32_t m_unNumResultsReturned;\n    uint32_t m_unTotalMatchingResults;\n    int8_t m_bCachedData;\n    uint8_t __pad_21[3];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_handle",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unNumResultsReturned",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unTotalMatchingResults",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamUGCQueryCompleted_t_143": {
    "body": "    uint64_t m_handle;\n    uint32_t m_eResult;\n    uint32_t m_unNumResultsReturned;\n    uint32_t m_unTotalMatchingResults;\n    int8_t m_bCachedData;\n    char (m_rgchNextCursor)[256];\n    uint8_t __pad_277[3];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_handle",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unNumResultsReturned",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unTotalMatchingResults",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 8
   },
   "SteamUnifiedMessagesSendMethodResult_t": {
    "body": "    uint64_t m_hHandle;\n    uint64_t m_unContext;\n    uint32_t m_eResult;\n    uint32_t m_unResponseSize;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_hHandle",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_unContext",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unResponseSize",
+     0
+    ]
+   ],
    "pack": 8
   },
   "StopPlaytimeTrackingResult_t": {
    "body": "    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "StoreAuthURLResponse_t": {
    "body": "    char (m_szURL)[512];",
+   "fields": [],
    "pack": 1
   },
   "SubmitItemUpdateResult_t_130": {
    "body": "    uint32_t m_eResult;\n    int8_t m_bUserNeedsToAcceptWorkshopLegalAgreement;\n    uint8_t __pad_5[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserNeedsToAcceptWorkshopLegalAgreement",
+     0
+    ]
+   ],
    "pack": 4
   },
   "SubmitItemUpdateResult_t_141": {
    "body": "    uint32_t m_eResult;\n    int8_t m_bUserNeedsToAcceptWorkshopLegalAgreement;\n    uint8_t __pad_5[3];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserNeedsToAcceptWorkshopLegalAgreement",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "TimedTrialStatus_t": {
    "body": "    uint32_t m_unAppID;\n    int8_t m_bIsOffline;\n    uint8_t __pad_5[3];\n    uint32_t m_unSecondsAllowed;\n    uint32_t m_unSecondsPlayed;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bIsOffline",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unSecondsAllowed",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unSecondsPlayed",
+     0
+    ]
+   ],
    "pack": 4
   },
   "UnreadChatMessagesChanged_t": {
    "body": "    uint8_t __pad_0[1];",
+   "fields": [],
    "pack": 1
   },
   "UserAchievementIconFetched_t": {
    "body": "    CGameID m_nGameID;\n    char (m_rgchAchievementName)[128];\n    int8_t m_bAchieved;\n    uint8_t __pad_137[3];\n    int32_t m_nIconHandle;",
+   "fields": [
+    [
+     "CGameID",
+     "m_nGameID",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAchieved",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nIconHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "UserAchievementStored_t": {
    "body": "    uint64_t m_nGameID;\n    int8_t m_bGroupAchievement;\n    char (m_rgchAchievementName)[128];\n    uint8_t __pad_137[3];\n    uint32_t m_nCurProgress;\n    uint32_t m_nMaxProgress;\n    uint8_t __pad_148[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nGameID",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bGroupAchievement",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCurProgress",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nMaxProgress",
+     0
+    ]
+   ],
    "pack": 8
   },
   "UserFavoriteItemsListChanged_t": {
    "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    int8_t m_bWasAddRequest;\n    uint8_t __pad_13[3];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bWasAddRequest",
+     0
+    ]
+   ],
    "pack": 8
   },
   "UserStatsReceived_t_099u": {
    "body": "    uint64_t m_nGameID;\n    uint32_t m_eResult;\n    uint8_t __pad_12[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 8
   },
   "UserStatsReceived_t_102x": {
    "body": "    uint64_t m_nGameID;\n    uint32_t m_eResult;\n    CSteamID m_steamIDUser;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ]
+   ],
    "pack": 8
   },
   "UserStatsStored_t": {
    "body": "    uint64_t m_nGameID;\n    uint32_t m_eResult;\n    uint8_t __pad_12[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 8
   },
   "UserStatsUnloaded_t": {
    "body": "    CSteamID m_steamIDUser;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ]
+   ],
    "pack": 1
   },
   "UserSubscribedItemsListChanged_t": {
    "body": "    uint32_t m_nAppID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "ValidateAuthTicketResponse_t_104": {
    "body": "    CSteamID m_SteamID;\n    uint32_t m_eAuthSessionResponse;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_SteamID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eAuthSessionResponse",
+     0
+    ]
+   ],
    "pack": 4
   },
   "ValidateAuthTicketResponse_t_126": {
    "body": "    CSteamID m_SteamID;\n    uint32_t m_eAuthSessionResponse;\n    CSteamID m_OwnerSteamID;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_SteamID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eAuthSessionResponse",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_OwnerSteamID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "VolumeHasChanged_t": {
    "body": "    float m_flNewVolume;",
+   "fields": [
+    [
+     "float",
+     "m_flNewVolume",
+     0
+    ]
+   ],
    "pack": 4
   },
   "WorkshopEULAStatus_t": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_nAppID;\n    uint32_t m_unVersion;\n    uint32_t m_rtAction;\n    int8_t m_bAccepted;\n    int8_t m_bNeedsAction;\n    uint8_t __pad_18[2];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVersion",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtAction",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAccepted",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bNeedsAction",
+     0
+    ]
+   ],
    "pack": 4
   },
   "gameserveritem_t_099u": {
    "body": "    servernetadr_t m_NetAdr;\n    int32_t m_nPing;\n    int8_t m_bHadSuccessfulResponse;\n    int8_t m_bDoNotRefresh;\n    char (m_szGameDir)[32];\n    char (m_szMap)[32];\n    char (m_szGameDescription)[64];\n    uint8_t __pad_142[2];\n    int32_t m_nAppID;\n    int32_t m_nPlayers;\n    int32_t m_nMaxPlayers;\n    int32_t m_nBotPlayers;\n    int8_t m_bPassword;\n    int8_t m_bSecure;\n    uint8_t __pad_162[2];\n    uint32_t m_ulTimeLastPlayed;\n    int32_t m_nServerVersion;\n    char (m_szServerName)[64];\n    char (m_szGameTags)[128];",
+   "fields": [
+    [
+     "servernetadr_t",
+     "m_NetAdr",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPing",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bHadSuccessfulResponse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bDoNotRefresh",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPlayers",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nMaxPlayers",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nBotPlayers",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bPassword",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bSecure",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_ulTimeLastPlayed",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nServerVersion",
+     0
+    ]
+   ],
    "pack": 4
   },
   "gameserveritem_t_105": {
    "body": "    servernetadr_t m_NetAdr;\n    int32_t m_nPing;\n    int8_t m_bHadSuccessfulResponse;\n    int8_t m_bDoNotRefresh;\n    char (m_szGameDir)[32];\n    char (m_szMap)[32];\n    char (m_szGameDescription)[64];\n    uint8_t __pad_142[2];\n    uint32_t m_nAppID;\n    int32_t m_nPlayers;\n    int32_t m_nMaxPlayers;\n    int32_t m_nBotPlayers;\n    int8_t m_bPassword;\n    int8_t m_bSecure;\n    uint8_t __pad_162[2];\n    uint32_t m_ulTimeLastPlayed;\n    int32_t m_nServerVersion;\n    char (m_szServerName)[64];\n    char (m_szGameTags)[128];\n    CSteamID m_steamID;",
+   "fields": [
+    [
+     "servernetadr_t",
+     "m_NetAdr",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPing",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bHadSuccessfulResponse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bDoNotRefresh",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPlayers",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nMaxPlayers",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nBotPlayers",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bPassword",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bSecure",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_ulTimeLastPlayed",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nServerVersion",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "gameserveritem_t_165": {
    "body": "    servernetadr_t m_NetAdr;\n    int32_t m_nPing;\n    int8_t m_bHadSuccessfulResponse;\n    int8_t m_bDoNotRefresh;\n    char (m_szGameDir)[32];\n    char (m_szMap)[32];\n    char (m_szGameDescription)[64];\n    uint8_t __pad_142[2];\n    uint32_t m_nAppID;\n    int32_t m_nPlayers;\n    int32_t m_nMaxPlayers;\n    int32_t m_nBotPlayers;\n    int8_t m_bPassword;\n    int8_t m_bSecure;\n    uint8_t __pad_162[2];\n    uint32_t m_ulTimeLastPlayed;\n    int32_t m_nServerVersion;\n    char (m_szServerName)[64];\n    char (m_szGameTags)[128];\n    CSteamID m_steamID;\n    int32_t m_nCurrentFriendCount;\n    int32_t m_nTotalFriendCount;",
+   "fields": [
+    [
+     "servernetadr_t",
+     "m_NetAdr",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPing",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bHadSuccessfulResponse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bDoNotRefresh",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPlayers",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nMaxPlayers",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nBotPlayers",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bPassword",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bSecure",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_ulTimeLastPlayed",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nServerVersion",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_steamID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nCurrentFriendCount",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalFriendCount",
+     0
+    ]
+   ],
    "pack": 4
   },
   "servernetadr_t": {
    "body": "    uint16_t m_usConnectionPort;\n    uint16_t m_usQueryPort;\n    uint32_t m_unIP;",
+   "fields": [
+    [
+     "uint16_t",
+     "m_usConnectionPort",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_usQueryPort",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unIP",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_AddAppDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_AddUGCDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint64_t m_nChildPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nChildPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_CreateBeaconCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_ulBeaconID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBeaconID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_CreateItemResult_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    int8_t m_bUserNeedsToAcceptWorkshopLegalAgreement;\n    uint8_t __pad_13[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserNeedsToAcceptWorkshopLegalAgreement",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_DeleteItemResult_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_DownloadItemResult_t": {
    "body": "    uint32_t m_unAppID;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_EndGameResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t ullUniqueGameID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "ullUniqueGameID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_FileDetailsResult_t": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_ulFileSize;\n    U32_ARRAY(uint8_t, 20, m_FileSHA);\n    uint32_t m_unFlags;",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_ulFileSize;\n    uint8_t m_FileSHA[20];\n    uint32_t m_unFlags;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulFileSize",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_FileSHA",
+     20
+    ],
+    [
+     "uint32_t",
+     "m_unFlags",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_GSReputation_t_108": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_unReputationScore;\n    int8_t m_bBanned;\n    uint8_t __pad_9[3];\n    uint32_t m_unBannedIP;\n    uint16_t m_usBannedPort;\n    uint8_t __pad_18[2];\n    uint64_t m_ulBannedGameID;\n    uint32_t m_unBanExpires;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unReputationScore",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBannedIP",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_usBannedPort",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBannedGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBanExpires",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_GSReputation_t_123": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_unReputationScore;\n    int8_t m_bBanned;\n    uint8_t __pad_9[3];\n    uint32_t m_unBannedIP;\n    uint16_t m_usBannedPort;\n    uint8_t __pad_18[2];\n    uint64_t m_ulBannedGameID;\n    uint32_t m_unBanExpires;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unReputationScore",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBannedIP",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_usBannedPort",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBannedGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBanExpires",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_GetAppDependenciesResult_t": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    U32_ARRAY(uint32_t, 32, m_rgAppIDs);\n    uint32_t m_nNumAppDependencies;\n    uint32_t m_nTotalNumAppDependencies;",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_rgAppIDs[32];\n    uint32_t m_nNumAppDependencies;\n    uint32_t m_nTotalNumAppDependencies;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rgAppIDs",
+     32
+    ],
+    [
+     "uint32_t",
+     "m_nNumAppDependencies",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nTotalNumAppDependencies",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTML_FileOpenDialog_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchTitle;\n    const char *pchInitialFile;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTML_FinishedRequest_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    const char *pchPageTitle;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTML_LinkAtPosition_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint32_t x;\n    uint32_t y;\n    const char *pchURL;\n    int8_t bInput;\n    int8_t bLiveLink;\n    uint8_t __pad_18[2];",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "x",
+     0
+    ],
+    [
+     "uint32_t",
+     "y",
+     0
+    ],
+    [
+     "int8_t",
+     "bInput",
+     0
+    ],
+    [
+     "int8_t",
+     "bLiveLink",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTML_NewWindow_t_130x": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    uint32_t unX;\n    uint32_t unY;\n    uint32_t unWide;\n    uint32_t unTall;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unY",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTML_NewWindow_t_132x": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    uint32_t unX;\n    uint32_t unY;\n    uint32_t unWide;\n    uint32_t unTall;\n    uint32_t unNewWindow_BrowserHandle_IGNORE;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unY",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ],
+    [
+     "uint32_t",
+     "unNewWindow_BrowserHandle_IGNORE",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTML_OpenLinkInNewTab_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTML_StartRequest_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    const char *pchTarget;\n    const char *pchPostData;\n    int8_t bIsRedirect;\n    uint8_t __pad_17[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "int8_t",
+     "bIsRedirect",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTML_URLChanged_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    const char *pchPostData;\n    int8_t bIsRedirect;\n    uint8_t __pad_13[3];\n    const char *pchPageTitle;\n    int8_t bNewNavigation;\n    uint8_t __pad_21[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "int8_t",
+     "bIsRedirect",
+     0
+    ],
+    [
+     "int8_t",
+     "bNewNavigation",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTTPRequestCompleted_t_115": {
    "body": "    uint32_t m_hRequest;\n    uint64_t m_ulContextValue;\n    int8_t m_bRequestSuccessful;\n    uint8_t __pad_13[3];\n    uint32_t m_eStatusCode;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bRequestSuccessful",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eStatusCode",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTTPRequestCompleted_t_123": {
    "body": "    uint32_t m_hRequest;\n    uint64_t m_ulContextValue;\n    int8_t m_bRequestSuccessful;\n    uint8_t __pad_13[3];\n    uint32_t m_eStatusCode;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bRequestSuccessful",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eStatusCode",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTTPRequestCompleted_t_132x": {
    "body": "    uint32_t m_hRequest;\n    uint64_t m_ulContextValue;\n    int8_t m_bRequestSuccessful;\n    uint8_t __pad_13[3];\n    uint32_t m_eStatusCode;\n    uint32_t m_unBodySize;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bRequestSuccessful",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eStatusCode",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBodySize",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTTPRequestDataReceived_t_121x": {
    "body": "    uint32_t m_hRequest;\n    uint64_t m_ulContextValue;\n    uint32_t m_cOffset;\n    uint32_t m_cBytesReceived;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cOffset",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cBytesReceived",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTTPRequestDataReceived_t_123": {
    "body": "    uint32_t m_hRequest;\n    uint64_t m_ulContextValue;\n    uint32_t m_cOffset;\n    uint32_t m_cBytesReceived;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cOffset",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cBytesReceived",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTTPRequestHeadersReceived_t_121x": {
    "body": "    uint32_t m_hRequest;\n    uint64_t m_ulContextValue;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_HTTPRequestHeadersReceived_t_123": {
    "body": "    uint32_t m_hRequest;\n    uint64_t m_ulContextValue;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_ItemInstalled_t_130": {
    "body": "    uint32_t m_unAppID;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_ItemInstalled_t_160": {
    "body": "    uint32_t m_unAppID;\n    uint64_t m_nPublishedFileId;\n    uint64_t m_hLegacyContent;\n    uint64_t m_unManifestID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hLegacyContent",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_unManifestID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_JoinPartyCallback_t": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_ulBeaconID;\n    CSteamID m_SteamIDBeaconOwner;\n    U32_ARRAY(char, 256, m_rgchConnectString);",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_ulBeaconID;\n    CSteamID m_SteamIDBeaconOwner;\n    char m_rgchConnectString[256];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBeaconID",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_SteamIDBeaconOwner",
+     0
+    ],
+    [
+     "char",
+     "m_rgchConnectString",
+     256
+    ]
+   ],
    "pack": 4
   },
   "u32_LeaderboardEntry_t_111x": {
    "body": "    CSteamID m_steamIDUser;\n    int32_t m_nGlobalRank;\n    int32_t m_nScore;\n    int32_t m_cDetails;\n    uint64_t m_hUGC;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRank",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cDetails",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hUGC",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_LeaderboardEntry_t_123": {
    "body": "    CSteamID m_steamIDUser;\n    int32_t m_nGlobalRank;\n    int32_t m_nScore;\n    int32_t m_cDetails;\n    uint64_t m_hUGC;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRank",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cDetails",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hUGC",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_LeaderboardScoreUploaded_t_104": {
    "body": "    uint8_t m_bSuccess;\n    uint8_t __pad_1[3];\n    uint64_t m_hSteamLeaderboard;\n    int32_t m_nScore;\n    uint8_t m_bScoreChanged;\n    uint8_t __pad_17[3];\n    int32_t m_nGlobalRankNew;\n    int32_t m_nGlobalRankPrevious;",
+   "fields": [
+    [
+     "uint8_t",
+     "m_bSuccess",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bScoreChanged",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRankNew",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRankPrevious",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_LeaderboardScoreUploaded_t_123": {
    "body": "    uint8_t m_bSuccess;\n    uint8_t __pad_1[3];\n    uint64_t m_hSteamLeaderboard;\n    int32_t m_nScore;\n    uint8_t m_bScoreChanged;\n    uint8_t __pad_17[3];\n    int32_t m_nGlobalRankNew;\n    int32_t m_nGlobalRankPrevious;",
+   "fields": [
+    [
+     "uint8_t",
+     "m_bSuccess",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bScoreChanged",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRankNew",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRankPrevious",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_LeaderboardUGCSet_t_111x": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_hSteamLeaderboard;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_LeaderboardUGCSet_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_hSteamLeaderboard;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_LobbyCreated_t_099u": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_ulSteamIDLobby;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_LobbyCreated_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_ulSteamIDLobby;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_MicroTxnAuthorizationResponse_t_109": {
    "body": "    uint32_t m_unAppID;\n    uint64_t m_ulOrderID;\n    uint8_t m_bAuthorized;\n    uint8_t __pad_13[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulOrderID",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bAuthorized",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_MicroTxnAuthorizationResponse_t_123": {
    "body": "    uint32_t m_unAppID;\n    uint64_t m_ulOrderID;\n    uint8_t m_bAuthorized;\n    uint8_t __pad_13[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulOrderID",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bAuthorized",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_PS3TrophiesInstalled_t_112x": {
    "body": "    uint64_t m_nGameID;\n    uint32_t m_eResult;\n    uint64_t m_ulRequiredDiskSpace;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulRequiredDiskSpace",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_PS3TrophiesInstalled_t_123": {
    "body": "    uint64_t m_nGameID;\n    uint32_t m_eResult;\n    uint64_t m_ulRequiredDiskSpace;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulRequiredDiskSpace",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageAppSyncProgress_t_111x": {
-   "body": "    U32_ARRAY(char, 260, m_rgchCurrentFile);\n    uint32_t m_nAppID;\n    uint32_t m_uBytesTransferredThisChunk;\n    double m_dAppPercentComplete;\n    int8_t m_bUploading;\n    uint8_t __pad_277[3];",
+   "body": "    char m_rgchCurrentFile[260];\n    uint32_t m_nAppID;\n    uint32_t m_uBytesTransferredThisChunk;\n    double m_dAppPercentComplete;\n    int8_t m_bUploading;\n    uint8_t __pad_277[3];",
+   "fields": [
+    [
+     "char",
+     "m_rgchCurrentFile",
+     260
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_uBytesTransferredThisChunk",
+     0
+    ],
+    [
+     "double",
+     "m_dAppPercentComplete",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUploading",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageAppSyncProgress_t_123": {
-   "body": "    U32_ARRAY(char, 260, m_rgchCurrentFile);\n    uint32_t m_nAppID;\n    uint32_t m_uBytesTransferredThisChunk;\n    double m_dAppPercentComplete;\n    int8_t m_bUploading;\n    uint8_t __pad_277[3];",
+   "body": "    char m_rgchCurrentFile[260];\n    uint32_t m_nAppID;\n    uint32_t m_uBytesTransferredThisChunk;\n    double m_dAppPercentComplete;\n    int8_t m_bUploading;\n    uint8_t __pad_277[3];",
+   "fields": [
+    [
+     "char",
+     "m_rgchCurrentFile",
+     260
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_uBytesTransferredThisChunk",
+     0
+    ],
+    [
+     "double",
+     "m_dAppPercentComplete",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUploading",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageDeletePublishedFileResult_t_116x": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageDeletePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageDownloadUGCResult_t_111x": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    char *m_pchFileName;\n    uint64_t m_ulSteamIDOwner;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSizeInBytes",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageDownloadUGCResult_t_116x": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    U32_ARRAY(char, 260, m_pchFileName);\n    uint64_t m_ulSteamIDOwner;",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    char m_pchFileName[260];\n    uint64_t m_ulSteamIDOwner;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSizeInBytes",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageDownloadUGCResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    U32_ARRAY(char, 260, m_pchFileName);\n    uint64_t m_ulSteamIDOwner;",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    char m_pchFileName[260];\n    uint64_t m_ulSteamIDOwner;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSizeInBytes",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageEnumerateUserPublishedFilesResult_t_116x": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    U32_ARRAY(uint64_t, 50, m_rgPublishedFileId);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t m_rgPublishedFileId[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageEnumerateUserPublishedFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    U32_ARRAY(uint64_t, 50, m_rgPublishedFileId);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t m_rgPublishedFileId[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageEnumerateUserSharedWorkshopFilesResult_t_119": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    U32_ARRAY(uint64_t, 50, m_rgPublishedFileId);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t m_rgPublishedFileId[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageEnumerateUserSharedWorkshopFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    U32_ARRAY(uint64_t, 50, m_rgPublishedFileId);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t m_rgPublishedFileId[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageEnumerateUserSubscribedFilesResult_t_116x": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    U32_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    U32_ARRAY(uint32_t, 50, m_rgRTimeSubscribed);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t m_rgPublishedFileId[50];\n    uint32_t m_rgRTimeSubscribed[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "uint32_t",
+     "m_rgRTimeSubscribed",
+     50
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageEnumerateUserSubscribedFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    U32_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    U32_ARRAY(uint32_t, 50, m_rgRTimeSubscribed);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t m_rgPublishedFileId[50];\n    uint32_t m_rgRTimeSubscribed[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "uint32_t",
+     "m_rgRTimeSubscribed",
+     50
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageEnumerateWorkshopFilesResult_t_119": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    U32_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    U32_ARRAY(float, 50, m_rgScore);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t m_rgPublishedFileId[50];\n    float m_rgScore[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "float",
+     "m_rgScore",
+     50
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageEnumerateWorkshopFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    U32_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    U32_ARRAY(float, 50, m_rgScore);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t m_rgPublishedFileId[50];\n    float m_rgScore[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "float",
+     "m_rgScore",
+     50
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageEnumerateWorkshopFilesResult_t_125": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    U32_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    U32_ARRAY(float, 50, m_rgScore);\n    uint32_t m_nAppId;\n    uint32_t m_unStartIndex;",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t m_rgPublishedFileId[50];\n    float m_rgScore[50];\n    uint32_t m_nAppId;\n    uint32_t m_unStartIndex;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "float",
+     "m_rgScore",
+     50
+    ],
+    [
+     "uint32_t",
+     "m_nAppId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unStartIndex",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageFileShareResult_t_111x": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_hFile;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageFileShareResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_hFile;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageFileShareResult_t_128x": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_hFile;\n    U32_ARRAY(char, 260, m_rgchFilename);",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_hFile;\n    char m_rgchFilename[260];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "char",
+     "m_rgchFilename",
+     260
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageGetPublishedFileDetailsResult_t_116x": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    U32_ARRAY(char, 129, m_rgchTitle);\n    U32_ARRAY(char, 257, m_rgchDescription);\n    uint8_t __pad_406[2];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    U32_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    U32_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_1731[1];",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[257];\n    uint8_t __pad_406[2];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_1731[1];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     257
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageGetPublishedFileDetailsResult_t_118": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    U32_ARRAY(char, 129, m_rgchTitle);\n    U32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8149[3];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    U32_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    U32_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9475[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8149[3];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9475[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageGetPublishedFileDetailsResult_t_119": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    U32_ARRAY(char, 129, m_rgchTitle);\n    U32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8149[3];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    U32_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    U32_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9475[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    U32_ARRAY(char, 256, m_rgchURL);",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8149[3];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9475[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageGetPublishedFileDetailsResult_t_119x": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    U32_ARRAY(char, 129, m_rgchTitle);\n    U32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8149[3];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    U32_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    U32_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9475[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    U32_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_eFileType;",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8149[3];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9475[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_eFileType;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageGetPublishedFileDetailsResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    U32_ARRAY(char, 129, m_rgchTitle);\n    U32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8149[3];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    U32_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    U32_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9475[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    U32_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_eFileType;",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8149[3];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9475[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_eFileType;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageGetPublishedFileDetailsResult_t_126": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    U32_ARRAY(char, 129, m_rgchTitle);\n    U32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8149[3];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    U32_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    U32_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9475[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    U32_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_eFileType;\n    int8_t m_bAcceptedForUse;\n    uint8_t __pad_9745[3];",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8149[3];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9475[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_eFileType;\n    int8_t m_bAcceptedForUse;\n    uint8_t __pad_9745[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageGetPublishedItemVoteDetailsResult_t_119": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_unPublishedFileId;\n    int32_t m_nVotesFor;\n    int32_t m_nVotesAgainst;\n    int32_t m_nReports;\n    float m_fScore;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_unPublishedFileId",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nVotesFor",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nVotesAgainst",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nReports",
+     0
+    ],
+    [
+     "float",
+     "m_fScore",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageGetPublishedItemVoteDetailsResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_unPublishedFileId;\n    int32_t m_nVotesFor;\n    int32_t m_nVotesAgainst;\n    int32_t m_nReports;\n    float m_fScore;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_unPublishedFileId",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nVotesFor",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nVotesAgainst",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nReports",
+     0
+    ],
+    [
+     "float",
+     "m_fScore",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStoragePublishFileResult_t_116x": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStoragePublishFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStoragePublishFileResult_t_125": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    int8_t m_bUserNeedsToAcceptWorkshopLegalAgreement;\n    uint8_t __pad_13[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserNeedsToAcceptWorkshopLegalAgreement",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStoragePublishedFileUpdated_t": {
    "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;\n    uint64_t m_ulUnused;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulUnused",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageSetUserPublishedFileActionResult_t_119": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eAction;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eAction",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageSetUserPublishedFileActionResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eAction;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eAction",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageSubscribePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageUnsubscribePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageUpdatePublishedFileResult_t_116x": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageUpdatePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageUpdatePublishedFileResult_t_125": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    int8_t m_bUserNeedsToAcceptWorkshopLegalAgreement;\n    uint8_t __pad_13[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserNeedsToAcceptWorkshopLegalAgreement",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageUpdateUserPublishedItemVoteResult_t_119": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageUpdateUserPublishedItemVoteResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageUserVoteDetails_t_119": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eVote;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVote",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoteStorageUserVoteDetails_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eVote;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVote",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoveAppDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RemoveUGCDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint64_t m_nChildPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nChildPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RequestPlayersForGameFinalResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_ullSearchID;\n    uint64_t m_ullUniqueGameID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullSearchID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullUniqueGameID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RequestPlayersForGameProgressCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_ullSearchID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullSearchID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_RequestPlayersForGameResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_ullSearchID;\n    CSteamID m_SteamIDPlayerFound;\n    CSteamID m_SteamIDLobby;\n    uint32_t m_ePlayerAcceptState;\n    int32_t m_nPlayerIndex;\n    int32_t m_nTotalPlayersFound;\n    int32_t m_nTotalPlayersAcceptedGame;\n    int32_t m_nSuggestedTeamIndex;\n    uint64_t m_ullUniqueGameID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullSearchID",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_SteamIDPlayerFound",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_SteamIDLobby",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_ePlayerAcceptState",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPlayerIndex",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalPlayersFound",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalPlayersAcceptedGame",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSuggestedTeamIndex",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullUniqueGameID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamInputConfigurationLoaded_t": {
    "body": "    uint32_t m_unAppID;\n    uint64_t m_ulDeviceHandle;\n    CSteamID m_ulMappingCreator;\n    uint32_t m_unMajorRevision;\n    uint32_t m_unMinorRevision;\n    int8_t m_bUsesSteamInputAPI;\n    int8_t m_bUsesGamepadAPI;\n    uint8_t __pad_30[2];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulDeviceHandle",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_ulMappingCreator",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unMajorRevision",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unMinorRevision",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUsesSteamInputAPI",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUsesGamepadAPI",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamInputGamepadSlotChange_t": {
    "body": "    uint32_t m_unAppID;\n    uint64_t m_ulDeviceHandle;\n    uint32_t m_eDeviceType;\n    int32_t m_nOldGamepadSlot;\n    int32_t m_nNewGamepadSlot;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulDeviceHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eDeviceType",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nOldGamepadSlot",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nNewGamepadSlot",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamInventoryStartPurchaseResult_t": {
    "body": "    uint32_t m_result;\n    uint64_t m_ulOrderID;\n    uint64_t m_ulTransID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_result",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulOrderID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulTransID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamNetConnectionStatusChangedCallback_t_144": {
    "body": "    uint32_t m_hConn;\n    SteamNetConnectionInfo_t_144 m_info;\n    uint32_t m_eOldState;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hConn",
+     0
+    ],
+    [
+     "SteamNetConnectionInfo_t_144",
+     "m_info",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eOldState",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamNetConnectionStatusChangedCallback_t_151": {
    "body": "    uint32_t m_hConn;\n    SteamNetConnectionInfo_t_151 m_info;\n    uint32_t m_eOldState;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hConn",
+     0
+    ],
+    [
+     "SteamNetConnectionInfo_t_151",
+     "m_info",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eOldState",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamNetConnectionStatusChangedCallback_t_153a": {
    "body": "    uint32_t m_hConn;\n    SteamNetConnectionInfo_t_153a m_info;\n    uint32_t m_eOldState;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hConn",
+     0
+    ],
+    [
+     "SteamNetConnectionInfo_t_153a",
+     "m_info",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eOldState",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamNetworkingMessage_t_144": {
    "body": "    void *m_pData;\n    uint32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_144 m_sender;\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*U_CDECL m_pfnFreeData)(u32_SteamNetworkingMessage_t_144 *);\n    void (*U_CDECL m_pfnRelease)(u32_SteamNetworkingMessage_t_144 *);\n    int32_t m_nChannel;\n    int32_t m___nPadDummy;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_144",
+     "m_sender",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m___nPadDummy",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamNetworkingMessage_t_147": {
    "body": "    void *m_pData;\n    int32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_144 m_identityPeer;\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*U_CDECL m_pfnFreeData)(u32_SteamNetworkingMessage_t_147 *);\n    void (*U_CDECL m_pfnRelease)(u32_SteamNetworkingMessage_t_147 *);\n    int32_t m_nChannel;\n    int32_t m_nFlags;\n    int64_t m_nUserData;",
+   "fields": [
+    [
+     "int32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_144",
+     "m_identityPeer",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nFlags",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamNetworkingMessage_t_151": {
    "body": "    void *m_pData;\n    int32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_151 m_identityPeer;\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*U_CDECL m_pfnFreeData)(u32_SteamNetworkingMessage_t_151 *);\n    void (*U_CDECL m_pfnRelease)(u32_SteamNetworkingMessage_t_151 *);\n    int32_t m_nChannel;\n    int32_t m_nFlags;\n    int64_t m_nUserData;",
+   "fields": [
+    [
+     "int32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_151",
+     "m_identityPeer",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nFlags",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamNetworkingMessage_t_153a": {
    "body": "    void *m_pData;\n    int32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_144 m_identityPeer;\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*U_CDECL m_pfnFreeData)(u32_SteamNetworkingMessage_t_153a *);\n    void (*U_CDECL m_pfnRelease)(u32_SteamNetworkingMessage_t_153a *);\n    int32_t m_nChannel;\n    int32_t m_nFlags;\n    int64_t m_nUserData;\n    uint16_t m_idxLane;\n    uint16_t _pad1__;",
+   "fields": [
+    [
+     "int32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_144",
+     "m_identityPeer",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nFlags",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_idxLane",
+     0
+    ],
+    [
+     "uint16_t",
+     "_pad1__",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamPartyBeaconLocation_t": {
    "body": "    uint32_t m_eType;\n    uint64_t m_ulLocationID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eType",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulLocationID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamUGCDetails_t_126": {
-   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    U32_ARRAY(char, 129, m_rgchTitle);\n    U32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[3];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    U32_ARRAY(char, 1025, m_rgchTags);\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    U32_ARRAY(char, 260, m_pchFileName);\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    U32_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;",
+   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[3];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    char m_rgchTags[1025];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    char m_pchFileName[260];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeAddedToUserList",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_unVotesUp",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVotesDown",
+     0
+    ],
+    [
+     "float",
+     "m_flScore",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamUGCDetails_t_128x": {
-   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    U32_ARRAY(char, 129, m_rgchTitle);\n    U32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[3];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    U32_ARRAY(char, 1025, m_rgchTags);\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    U32_ARRAY(char, 260, m_pchFileName);\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    U32_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;",
+   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[3];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    char m_rgchTags[1025];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    char m_pchFileName[260];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeAddedToUserList",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_unVotesUp",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVotesDown",
+     0
+    ],
+    [
+     "float",
+     "m_flScore",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unNumChildren",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamUGCDetails_t_160": {
-   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    U32_ARRAY(char, 129, m_rgchTitle);\n    U32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[3];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    U32_ARRAY(char, 1025, m_rgchTags);\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    U32_ARRAY(char, 260, m_pchFileName);\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    U32_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;\n    uint64_t m_ulTotalFilesSize;",
+   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[3];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    char m_rgchTags[1025];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    char m_pchFileName[260];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;\n    uint64_t m_ulTotalFilesSize;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeAddedToUserList",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_unVotesUp",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVotesDown",
+     0
+    ],
+    [
+     "float",
+     "m_flScore",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unNumChildren",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulTotalFilesSize",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamUGCRequestUGCDetailsResult_t_126": {
    "body": "    u32_SteamUGCDetails_t_126 m_details;",
+   "fields": [
+    [
+     "u32_SteamUGCDetails_t_126",
+     "m_details",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamUGCRequestUGCDetailsResult_t_128x": {
    "body": "    u32_SteamUGCDetails_t_128x m_details;\n    int8_t m_bCachedData;\n    uint8_t __pad_9765[3];",
+   "fields": [
+    [
+     "u32_SteamUGCDetails_t_128x",
+     "m_details",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamUGCRequestUGCDetailsResult_t_129": {
    "body": "    u32_SteamUGCDetails_t_126 m_details;\n    int8_t m_bCachedData;\n    uint8_t __pad_9761[3];",
+   "fields": [
+    [
+     "u32_SteamUGCDetails_t_126",
+     "m_details",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SteamUGCRequestUGCDetailsResult_t_160": {
    "body": "    u32_SteamUGCDetails_t_160 m_details;\n    int8_t m_bCachedData;\n    uint8_t __pad_9773[3];",
+   "fields": [
+    [
+     "u32_SteamUGCDetails_t_160",
+     "m_details",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u32_SubmitPlayerResultResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t ullUniqueGameID;\n    CSteamID steamIDPlayer;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "ullUniqueGameID",
+     0
+    ],
+    [
+     "CSteamID",
+     "steamIDPlayer",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_AddAppDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_AddUGCDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint64_t m_nChildPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nChildPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_CreateBeaconCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_ulBeaconID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBeaconID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_CreateItemResult_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    int8_t m_bUserNeedsToAcceptWorkshopLegalAgreement;\n    uint8_t __pad_13[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserNeedsToAcceptWorkshopLegalAgreement",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_DeleteItemResult_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_DownloadItemResult_t": {
    "body": "    uint32_t m_unAppID;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_EndGameResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t ullUniqueGameID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "ullUniqueGameID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_FileDetailsResult_t": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_ulFileSize;\n    U64_ARRAY(uint8_t, 20, m_FileSHA);\n    uint32_t m_unFlags;",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_ulFileSize;\n    uint8_t m_FileSHA[20];\n    uint32_t m_unFlags;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulFileSize",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_FileSHA",
+     20
+    ],
+    [
+     "uint32_t",
+     "m_unFlags",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_GSReputation_t_123": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_unReputationScore;\n    int8_t m_bBanned;\n    uint8_t __pad_9[3];\n    uint32_t m_unBannedIP;\n    uint16_t m_usBannedPort;\n    uint8_t __pad_18[2];\n    uint64_t m_ulBannedGameID;\n    uint32_t m_unBanExpires;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unReputationScore",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBannedIP",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_usBannedPort",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBannedGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBanExpires",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_GetAppDependenciesResult_t": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    U64_ARRAY(uint32_t, 32, m_rgAppIDs);\n    uint32_t m_nNumAppDependencies;\n    uint32_t m_nTotalNumAppDependencies;",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_rgAppIDs[32];\n    uint32_t m_nNumAppDependencies;\n    uint32_t m_nTotalNumAppDependencies;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rgAppIDs",
+     32
+    ],
+    [
+     "uint32_t",
+     "m_nNumAppDependencies",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nTotalNumAppDependencies",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_ChangedTitle_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchTitle;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_ComboNeedsPaint_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pBGRA;\n    uint32_t unWide;\n    uint32_t unTall;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_FileOpenDialog_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchTitle;\n    const char *pchInitialFile;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_FinishedRequest_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    const char *pchPageTitle;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_JSAlert_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchMessage;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_JSConfirm_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchMessage;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_LinkAtPosition_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint32_t x;\n    uint32_t y;\n    const char *pchURL;\n    int8_t bInput;\n    int8_t bLiveLink;\n    uint8_t __pad_22[2];",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "x",
+     0
+    ],
+    [
+     "uint32_t",
+     "y",
+     0
+    ],
+    [
+     "int8_t",
+     "bInput",
+     0
+    ],
+    [
+     "int8_t",
+     "bLiveLink",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_NeedsPaint_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pBGRA;\n    uint32_t unWide;\n    uint32_t unTall;\n    uint32_t unUpdateX;\n    uint32_t unUpdateY;\n    uint32_t unUpdateWide;\n    uint32_t unUpdateTall;\n    uint32_t unScrollX;\n    uint32_t unScrollY;\n    float flPageScale;\n    uint32_t unPageSerial;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ],
+    [
+     "uint32_t",
+     "unUpdateX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unUpdateY",
+     0
+    ],
+    [
+     "uint32_t",
+     "unUpdateWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unUpdateTall",
+     0
+    ],
+    [
+     "uint32_t",
+     "unScrollX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unScrollY",
+     0
+    ],
+    [
+     "float",
+     "flPageScale",
+     0
+    ],
+    [
+     "uint32_t",
+     "unPageSerial",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_NewWindow_t_130x": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    uint32_t unX;\n    uint32_t unY;\n    uint32_t unWide;\n    uint32_t unTall;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unY",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_NewWindow_t_132x": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    uint32_t unX;\n    uint32_t unY;\n    uint32_t unWide;\n    uint32_t unTall;\n    uint32_t unNewWindow_BrowserHandle_IGNORE;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unY",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ],
+    [
+     "uint32_t",
+     "unNewWindow_BrowserHandle_IGNORE",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_OpenLinkInNewTab_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_ShowToolTip_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchMsg;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_StartRequest_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    const char *pchTarget;\n    const char *pchPostData;\n    int8_t bIsRedirect;\n    uint8_t __pad_29[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "int8_t",
+     "bIsRedirect",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_StatusText_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchMsg;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_URLChanged_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    const char *pchPostData;\n    int8_t bIsRedirect;\n    uint8_t __pad_21[3];\n    const char *pchPageTitle;\n    int8_t bNewNavigation;\n    uint8_t __pad_33[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "int8_t",
+     "bIsRedirect",
+     0
+    ],
+    [
+     "int8_t",
+     "bNewNavigation",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTML_UpdateToolTip_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchMsg;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTTPRequestCompleted_t_123": {
    "body": "    uint32_t m_hRequest;\n    uint64_t m_ulContextValue;\n    int8_t m_bRequestSuccessful;\n    uint8_t __pad_13[3];\n    uint32_t m_eStatusCode;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bRequestSuccessful",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eStatusCode",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTTPRequestCompleted_t_132x": {
    "body": "    uint32_t m_hRequest;\n    uint64_t m_ulContextValue;\n    int8_t m_bRequestSuccessful;\n    uint8_t __pad_13[3];\n    uint32_t m_eStatusCode;\n    uint32_t m_unBodySize;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bRequestSuccessful",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eStatusCode",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBodySize",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTTPRequestDataReceived_t_123": {
    "body": "    uint32_t m_hRequest;\n    uint64_t m_ulContextValue;\n    uint32_t m_cOffset;\n    uint32_t m_cBytesReceived;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cOffset",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cBytesReceived",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_HTTPRequestHeadersReceived_t_123": {
    "body": "    uint32_t m_hRequest;\n    uint64_t m_ulContextValue;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_ItemInstalled_t_130": {
    "body": "    uint32_t m_unAppID;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_ItemInstalled_t_160": {
    "body": "    uint32_t m_unAppID;\n    uint64_t m_nPublishedFileId;\n    uint64_t m_hLegacyContent;\n    uint64_t m_unManifestID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hLegacyContent",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_unManifestID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_JoinPartyCallback_t": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_ulBeaconID;\n    CSteamID m_SteamIDBeaconOwner;\n    U64_ARRAY(char, 256, m_rgchConnectString);",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_ulBeaconID;\n    CSteamID m_SteamIDBeaconOwner;\n    char m_rgchConnectString[256];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBeaconID",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_SteamIDBeaconOwner",
+     0
+    ],
+    [
+     "char",
+     "m_rgchConnectString",
+     256
+    ]
+   ],
    "pack": 4
   },
   "u64_LeaderboardEntry_t_123": {
    "body": "    CSteamID m_steamIDUser;\n    int32_t m_nGlobalRank;\n    int32_t m_nScore;\n    int32_t m_cDetails;\n    uint64_t m_hUGC;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRank",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cDetails",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hUGC",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_LeaderboardScoreUploaded_t_123": {
    "body": "    uint8_t m_bSuccess;\n    uint8_t __pad_1[3];\n    uint64_t m_hSteamLeaderboard;\n    int32_t m_nScore;\n    uint8_t m_bScoreChanged;\n    uint8_t __pad_17[3];\n    int32_t m_nGlobalRankNew;\n    int32_t m_nGlobalRankPrevious;",
+   "fields": [
+    [
+     "uint8_t",
+     "m_bSuccess",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bScoreChanged",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRankNew",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRankPrevious",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_LeaderboardUGCSet_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_hSteamLeaderboard;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_LobbyCreated_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_ulSteamIDLobby;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_MicroTxnAuthorizationResponse_t_123": {
    "body": "    uint32_t m_unAppID;\n    uint64_t m_ulOrderID;\n    uint8_t m_bAuthorized;\n    uint8_t __pad_13[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulOrderID",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bAuthorized",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_PS3TrophiesInstalled_t_123": {
    "body": "    uint64_t m_nGameID;\n    uint32_t m_eResult;\n    uint64_t m_ulRequiredDiskSpace;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulRequiredDiskSpace",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageAppSyncProgress_t_123": {
-   "body": "    U64_ARRAY(char, 260, m_rgchCurrentFile);\n    uint32_t m_nAppID;\n    uint32_t m_uBytesTransferredThisChunk;\n    double m_dAppPercentComplete;\n    int8_t m_bUploading;\n    uint8_t __pad_277[3];",
+   "body": "    char m_rgchCurrentFile[260];\n    uint32_t m_nAppID;\n    uint32_t m_uBytesTransferredThisChunk;\n    double m_dAppPercentComplete;\n    int8_t m_bUploading;\n    uint8_t __pad_277[3];",
+   "fields": [
+    [
+     "char",
+     "m_rgchCurrentFile",
+     260
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_uBytesTransferredThisChunk",
+     0
+    ],
+    [
+     "double",
+     "m_dAppPercentComplete",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUploading",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageDeletePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageDownloadUGCResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    U64_ARRAY(char, 260, m_pchFileName);\n    uint64_t m_ulSteamIDOwner;",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    char m_pchFileName[260];\n    uint64_t m_ulSteamIDOwner;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSizeInBytes",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageEnumerateUserPublishedFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    U64_ARRAY(uint64_t, 50, m_rgPublishedFileId);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t m_rgPublishedFileId[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageEnumerateUserSharedWorkshopFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    U64_ARRAY(uint64_t, 50, m_rgPublishedFileId);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t m_rgPublishedFileId[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageEnumerateUserSubscribedFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    U64_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    U64_ARRAY(uint32_t, 50, m_rgRTimeSubscribed);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t m_rgPublishedFileId[50];\n    uint32_t m_rgRTimeSubscribed[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "uint32_t",
+     "m_rgRTimeSubscribed",
+     50
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageEnumerateWorkshopFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    U64_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    U64_ARRAY(float, 50, m_rgScore);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t m_rgPublishedFileId[50];\n    float m_rgScore[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "float",
+     "m_rgScore",
+     50
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageEnumerateWorkshopFilesResult_t_125": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    U64_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    U64_ARRAY(float, 50, m_rgScore);\n    uint32_t m_nAppId;\n    uint32_t m_unStartIndex;",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint64_t m_rgPublishedFileId[50];\n    float m_rgScore[50];\n    uint32_t m_nAppId;\n    uint32_t m_unStartIndex;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "float",
+     "m_rgScore",
+     50
+    ],
+    [
+     "uint32_t",
+     "m_nAppId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unStartIndex",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageFileShareResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_hFile;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageFileShareResult_t_128x": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_hFile;\n    U64_ARRAY(char, 260, m_rgchFilename);",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_hFile;\n    char m_rgchFilename[260];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "char",
+     "m_rgchFilename",
+     260
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageGetPublishedFileDetailsResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    U64_ARRAY(char, 129, m_rgchTitle);\n    U64_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8149[3];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    U64_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    U64_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9475[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    U64_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_eFileType;",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8149[3];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9475[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_eFileType;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageGetPublishedFileDetailsResult_t_126": {
-   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    U64_ARRAY(char, 129, m_rgchTitle);\n    U64_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8149[3];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    U64_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    U64_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9475[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    U64_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_eFileType;\n    int8_t m_bAcceptedForUse;\n    uint8_t __pad_9745[3];",
+   "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8149[3];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9475[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_eFileType;\n    int8_t m_bAcceptedForUse;\n    uint8_t __pad_9745[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageGetPublishedItemVoteDetailsResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_unPublishedFileId;\n    int32_t m_nVotesFor;\n    int32_t m_nVotesAgainst;\n    int32_t m_nReports;\n    float m_fScore;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_unPublishedFileId",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nVotesFor",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nVotesAgainst",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nReports",
+     0
+    ],
+    [
+     "float",
+     "m_fScore",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStoragePublishFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStoragePublishFileResult_t_125": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    int8_t m_bUserNeedsToAcceptWorkshopLegalAgreement;\n    uint8_t __pad_13[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserNeedsToAcceptWorkshopLegalAgreement",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStoragePublishedFileUpdated_t": {
    "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;\n    uint64_t m_ulUnused;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulUnused",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageSetUserPublishedFileActionResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eAction;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eAction",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageSubscribePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageUnsubscribePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageUpdatePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageUpdatePublishedFileResult_t_125": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    int8_t m_bUserNeedsToAcceptWorkshopLegalAgreement;\n    uint8_t __pad_13[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserNeedsToAcceptWorkshopLegalAgreement",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageUpdateUserPublishedItemVoteResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoteStorageUserVoteDetails_t_123": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eVote;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVote",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoveAppDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RemoveUGCDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_nPublishedFileId;\n    uint64_t m_nChildPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nChildPublishedFileId",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RequestPlayersForGameFinalResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_ullSearchID;\n    uint64_t m_ullUniqueGameID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullSearchID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullUniqueGameID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RequestPlayersForGameProgressCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_ullSearchID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullSearchID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_RequestPlayersForGameResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t m_ullSearchID;\n    CSteamID m_SteamIDPlayerFound;\n    CSteamID m_SteamIDLobby;\n    uint32_t m_ePlayerAcceptState;\n    int32_t m_nPlayerIndex;\n    int32_t m_nTotalPlayersFound;\n    int32_t m_nTotalPlayersAcceptedGame;\n    int32_t m_nSuggestedTeamIndex;\n    uint64_t m_ullUniqueGameID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullSearchID",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_SteamIDPlayerFound",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_SteamIDLobby",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_ePlayerAcceptState",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPlayerIndex",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalPlayersFound",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalPlayersAcceptedGame",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSuggestedTeamIndex",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullUniqueGameID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SteamInputConfigurationLoaded_t": {
    "body": "    uint32_t m_unAppID;\n    uint64_t m_ulDeviceHandle;\n    CSteamID m_ulMappingCreator;\n    uint32_t m_unMajorRevision;\n    uint32_t m_unMinorRevision;\n    int8_t m_bUsesSteamInputAPI;\n    int8_t m_bUsesGamepadAPI;\n    uint8_t __pad_30[2];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulDeviceHandle",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_ulMappingCreator",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unMajorRevision",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unMinorRevision",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUsesSteamInputAPI",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUsesGamepadAPI",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SteamInputGamepadSlotChange_t": {
    "body": "    uint32_t m_unAppID;\n    uint64_t m_ulDeviceHandle;\n    uint32_t m_eDeviceType;\n    int32_t m_nOldGamepadSlot;\n    int32_t m_nNewGamepadSlot;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulDeviceHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eDeviceType",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nOldGamepadSlot",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nNewGamepadSlot",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SteamInventoryStartPurchaseResult_t": {
    "body": "    uint32_t m_result;\n    uint64_t m_ulOrderID;\n    uint64_t m_ulTransID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_result",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulOrderID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulTransID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SteamNetConnectionStatusChangedCallback_t_144": {
    "body": "    uint32_t m_hConn;\n    SteamNetConnectionInfo_t_144 m_info;\n    uint32_t m_eOldState;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hConn",
+     0
+    ],
+    [
+     "SteamNetConnectionInfo_t_144",
+     "m_info",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eOldState",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SteamNetConnectionStatusChangedCallback_t_151": {
    "body": "    uint32_t m_hConn;\n    SteamNetConnectionInfo_t_151 m_info;\n    uint32_t m_eOldState;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hConn",
+     0
+    ],
+    [
+     "SteamNetConnectionInfo_t_151",
+     "m_info",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eOldState",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SteamNetConnectionStatusChangedCallback_t_153a": {
    "body": "    uint32_t m_hConn;\n    SteamNetConnectionInfo_t_153a m_info;\n    uint32_t m_eOldState;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hConn",
+     0
+    ],
+    [
+     "SteamNetConnectionInfo_t_153a",
+     "m_info",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eOldState",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SteamNetworkingMessage_t_144": {
    "body": "    void *m_pData;\n    uint32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_144 m_sender;\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*U_CDECL m_pfnFreeData)(u64_SteamNetworkingMessage_t_144 *);\n    void (*U_CDECL m_pfnRelease)(u64_SteamNetworkingMessage_t_144 *);\n    int32_t m_nChannel;\n    int32_t m___nPadDummy;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_144",
+     "m_sender",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m___nPadDummy",
+     0
+    ]
+   ],
    "pack": 8
   },
   "u64_SteamNetworkingMessage_t_147": {
    "body": "    void *m_pData;\n    int32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_144 m_identityPeer;\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*U_CDECL m_pfnFreeData)(u64_SteamNetworkingMessage_t_147 *);\n    void (*U_CDECL m_pfnRelease)(u64_SteamNetworkingMessage_t_147 *);\n    int32_t m_nChannel;\n    int32_t m_nFlags;\n    int64_t m_nUserData;",
+   "fields": [
+    [
+     "int32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_144",
+     "m_identityPeer",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nFlags",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ]
+   ],
    "pack": 8
   },
   "u64_SteamNetworkingMessage_t_151": {
    "body": "    void *m_pData;\n    int32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_151 m_identityPeer;\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*U_CDECL m_pfnFreeData)(u64_SteamNetworkingMessage_t_151 *);\n    void (*U_CDECL m_pfnRelease)(u64_SteamNetworkingMessage_t_151 *);\n    int32_t m_nChannel;\n    int32_t m_nFlags;\n    int64_t m_nUserData;",
+   "fields": [
+    [
+     "int32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_151",
+     "m_identityPeer",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nFlags",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ]
+   ],
    "pack": 8
   },
   "u64_SteamNetworkingMessage_t_153a": {
    "body": "    void *m_pData;\n    int32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_144 m_identityPeer;\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*U_CDECL m_pfnFreeData)(u64_SteamNetworkingMessage_t_153a *);\n    void (*U_CDECL m_pfnRelease)(u64_SteamNetworkingMessage_t_153a *);\n    int32_t m_nChannel;\n    int32_t m_nFlags;\n    int64_t m_nUserData;\n    uint16_t m_idxLane;\n    uint16_t _pad1__;\n    uint8_t __pad_212[4];",
+   "fields": [
+    [
+     "int32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_144",
+     "m_identityPeer",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nFlags",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_idxLane",
+     0
+    ],
+    [
+     "uint16_t",
+     "_pad1__",
+     0
+    ]
+   ],
    "pack": 8
   },
   "u64_SteamPartyBeaconLocation_t": {
    "body": "    uint32_t m_eType;\n    uint64_t m_ulLocationID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eType",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulLocationID",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SteamUGCDetails_t_126": {
-   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    U64_ARRAY(char, 129, m_rgchTitle);\n    U64_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[3];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    U64_ARRAY(char, 1025, m_rgchTags);\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    U64_ARRAY(char, 260, m_pchFileName);\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    U64_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;",
+   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[3];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    char m_rgchTags[1025];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    char m_pchFileName[260];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeAddedToUserList",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_unVotesUp",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVotesDown",
+     0
+    ],
+    [
+     "float",
+     "m_flScore",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SteamUGCDetails_t_128x": {
-   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    U64_ARRAY(char, 129, m_rgchTitle);\n    U64_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[3];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    U64_ARRAY(char, 1025, m_rgchTags);\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    U64_ARRAY(char, 260, m_pchFileName);\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    U64_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;",
+   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[3];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    char m_rgchTags[1025];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    char m_pchFileName[260];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeAddedToUserList",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_unVotesUp",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVotesDown",
+     0
+    ],
+    [
+     "float",
+     "m_flScore",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unNumChildren",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SteamUGCDetails_t_160": {
-   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    U64_ARRAY(char, 129, m_rgchTitle);\n    U64_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[3];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    U64_ARRAY(char, 1025, m_rgchTags);\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    U64_ARRAY(char, 260, m_pchFileName);\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    U64_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;\n    uint64_t m_ulTotalFilesSize;",
+   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[3];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    char m_rgchTags[1025];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    char m_pchFileName[260];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;\n    uint64_t m_ulTotalFilesSize;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeAddedToUserList",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_unVotesUp",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVotesDown",
+     0
+    ],
+    [
+     "float",
+     "m_flScore",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unNumChildren",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulTotalFilesSize",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SteamUGCRequestUGCDetailsResult_t_126": {
    "body": "    u64_SteamUGCDetails_t_126 m_details;",
+   "fields": [
+    [
+     "u64_SteamUGCDetails_t_126",
+     "m_details",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SteamUGCRequestUGCDetailsResult_t_128x": {
    "body": "    u64_SteamUGCDetails_t_128x m_details;\n    int8_t m_bCachedData;\n    uint8_t __pad_9765[3];",
+   "fields": [
+    [
+     "u64_SteamUGCDetails_t_128x",
+     "m_details",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SteamUGCRequestUGCDetailsResult_t_129": {
    "body": "    u64_SteamUGCDetails_t_126 m_details;\n    int8_t m_bCachedData;\n    uint8_t __pad_9761[3];",
+   "fields": [
+    [
+     "u64_SteamUGCDetails_t_126",
+     "m_details",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SteamUGCRequestUGCDetailsResult_t_160": {
    "body": "    u64_SteamUGCDetails_t_160 m_details;\n    int8_t m_bCachedData;\n    uint8_t __pad_9773[3];",
+   "fields": [
+    [
+     "u64_SteamUGCDetails_t_160",
+     "m_details",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 4
   },
   "u64_SubmitPlayerResultResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint64_t ullUniqueGameID;\n    CSteamID steamIDPlayer;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "ullUniqueGameID",
+     0
+    ],
+    [
+     "CSteamID",
+     "steamIDPlayer",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_AddAppDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_AddUGCDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint64_t m_nChildPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nChildPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_CallbackMsg_t": {
    "body": "    int32_t m_hSteamUser;\n    int32_t m_iCallback;\n    uint8_t *m_pubParam;\n    int32_t m_cubParam;",
+   "fields": [
+    [
+     "int32_t",
+     "m_hSteamUser",
+     0
+    ],
+    [
+     "int32_t",
+     "m_iCallback",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cubParam",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_CreateBeaconCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ulBeaconID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBeaconID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_CreateItemResult_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    int8_t m_bUserNeedsToAcceptWorkshopLegalAgreement;\n    uint8_t __pad_17[7];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserNeedsToAcceptWorkshopLegalAgreement",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_DeleteItemResult_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_DownloadItemResult_t": {
    "body": "    uint32_t m_unAppID;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_EndGameResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t ullUniqueGameID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "ullUniqueGameID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_FileDetailsResult_t": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ulFileSize;\n    W32_ARRAY(uint8_t, 20, m_FileSHA);\n    uint32_t m_unFlags;",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ulFileSize;\n    uint8_t m_FileSHA[20];\n    uint32_t m_unFlags;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulFileSize",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_FileSHA",
+     20
+    ],
+    [
+     "uint32_t",
+     "m_unFlags",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_GSReputation_t_108": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_unReputationScore;\n    int8_t m_bBanned;\n    uint8_t __pad_9[3];\n    uint32_t m_unBannedIP;\n    uint16_t m_usBannedPort;\n    uint8_t __pad_18[6];\n    uint64_t m_ulBannedGameID;\n    uint32_t m_unBanExpires;\n    uint8_t __pad_36[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unReputationScore",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBannedIP",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_usBannedPort",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBannedGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBanExpires",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_GSReputation_t_123": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_unReputationScore;\n    int8_t m_bBanned;\n    uint8_t __pad_9[3];\n    uint32_t m_unBannedIP;\n    uint16_t m_usBannedPort;\n    uint8_t __pad_18[6];\n    uint64_t m_ulBannedGameID;\n    uint32_t m_unBanExpires;\n    uint8_t __pad_36[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unReputationScore",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBannedIP",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_usBannedPort",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBannedGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBanExpires",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_GetAppDependenciesResult_t": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    W32_ARRAY(uint32_t, 32, m_rgAppIDs);\n    uint32_t m_nNumAppDependencies;\n    uint32_t m_nTotalNumAppDependencies;",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_rgAppIDs[32];\n    uint32_t m_nNumAppDependencies;\n    uint32_t m_nTotalNumAppDependencies;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rgAppIDs",
+     32
+    ],
+    [
+     "uint32_t",
+     "m_nNumAppDependencies",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nTotalNumAppDependencies",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_HTML_ChangedTitle_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchTitle;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_ComboNeedsPaint_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pBGRA;\n    uint32_t unWide;\n    uint32_t unTall;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_FileOpenDialog_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchTitle;\n    const char *pchInitialFile;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_FinishedRequest_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    const char *pchPageTitle;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_JSAlert_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchMessage;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_JSConfirm_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchMessage;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_LinkAtPosition_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint32_t x;\n    uint32_t y;\n    const char *pchURL;\n    int8_t bInput;\n    int8_t bLiveLink;\n    uint8_t __pad_18[2];",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "x",
+     0
+    ],
+    [
+     "uint32_t",
+     "y",
+     0
+    ],
+    [
+     "int8_t",
+     "bInput",
+     0
+    ],
+    [
+     "int8_t",
+     "bLiveLink",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_NeedsPaint_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pBGRA;\n    uint32_t unWide;\n    uint32_t unTall;\n    uint32_t unUpdateX;\n    uint32_t unUpdateY;\n    uint32_t unUpdateWide;\n    uint32_t unUpdateTall;\n    uint32_t unScrollX;\n    uint32_t unScrollY;\n    float flPageScale;\n    uint32_t unPageSerial;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ],
+    [
+     "uint32_t",
+     "unUpdateX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unUpdateY",
+     0
+    ],
+    [
+     "uint32_t",
+     "unUpdateWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unUpdateTall",
+     0
+    ],
+    [
+     "uint32_t",
+     "unScrollX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unScrollY",
+     0
+    ],
+    [
+     "float",
+     "flPageScale",
+     0
+    ],
+    [
+     "uint32_t",
+     "unPageSerial",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_NewWindow_t_130x": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    uint32_t unX;\n    uint32_t unY;\n    uint32_t unWide;\n    uint32_t unTall;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unY",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_NewWindow_t_132x": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    uint32_t unX;\n    uint32_t unY;\n    uint32_t unWide;\n    uint32_t unTall;\n    uint32_t unNewWindow_BrowserHandle_IGNORE;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unY",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ],
+    [
+     "uint32_t",
+     "unNewWindow_BrowserHandle_IGNORE",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_OpenLinkInNewTab_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_ShowToolTip_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchMsg;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_StartRequest_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    const char *pchTarget;\n    const char *pchPostData;\n    int8_t bIsRedirect;\n    uint8_t __pad_17[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "int8_t",
+     "bIsRedirect",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_StatusText_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchMsg;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_URLChanged_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchURL;\n    const char *pchPostData;\n    int8_t bIsRedirect;\n    uint8_t __pad_13[3];\n    const char *pchPageTitle;\n    int8_t bNewNavigation;\n    uint8_t __pad_21[3];",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "int8_t",
+     "bIsRedirect",
+     0
+    ],
+    [
+     "int8_t",
+     "bNewNavigation",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTML_UpdateToolTip_t": {
    "body": "    uint32_t unBrowserHandle;\n    const char *pchMsg;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_HTTPRequestCompleted_t_115": {
    "body": "    uint32_t m_hRequest;\n    uint8_t __pad_4[4];\n    uint64_t m_ulContextValue;\n    int8_t m_bRequestSuccessful;\n    uint8_t __pad_17[3];\n    uint32_t m_eStatusCode;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bRequestSuccessful",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eStatusCode",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_HTTPRequestCompleted_t_123": {
    "body": "    uint32_t m_hRequest;\n    uint8_t __pad_4[4];\n    uint64_t m_ulContextValue;\n    int8_t m_bRequestSuccessful;\n    uint8_t __pad_17[3];\n    uint32_t m_eStatusCode;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bRequestSuccessful",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eStatusCode",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_HTTPRequestCompleted_t_132x": {
    "body": "    uint32_t m_hRequest;\n    uint8_t __pad_4[4];\n    uint64_t m_ulContextValue;\n    int8_t m_bRequestSuccessful;\n    uint8_t __pad_17[3];\n    uint32_t m_eStatusCode;\n    uint32_t m_unBodySize;\n    uint8_t __pad_28[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bRequestSuccessful",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eStatusCode",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBodySize",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_HTTPRequestDataReceived_t_121x": {
    "body": "    uint32_t m_hRequest;\n    uint8_t __pad_4[4];\n    uint64_t m_ulContextValue;\n    uint32_t m_cOffset;\n    uint32_t m_cBytesReceived;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cOffset",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cBytesReceived",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_HTTPRequestDataReceived_t_123": {
    "body": "    uint32_t m_hRequest;\n    uint8_t __pad_4[4];\n    uint64_t m_ulContextValue;\n    uint32_t m_cOffset;\n    uint32_t m_cBytesReceived;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cOffset",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cBytesReceived",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_HTTPRequestHeadersReceived_t_121x": {
    "body": "    uint32_t m_hRequest;\n    uint8_t __pad_4[4];\n    uint64_t m_ulContextValue;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_HTTPRequestHeadersReceived_t_123": {
    "body": "    uint32_t m_hRequest;\n    uint8_t __pad_4[4];\n    uint64_t m_ulContextValue;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_ItemInstalled_t_130": {
    "body": "    uint32_t m_unAppID;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_ItemInstalled_t_160": {
    "body": "    uint32_t m_unAppID;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint64_t m_hLegacyContent;\n    uint64_t m_unManifestID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hLegacyContent",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_unManifestID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_JoinPartyCallback_t": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ulBeaconID;\n    CSteamID m_SteamIDBeaconOwner;\n    W32_ARRAY(char, 256, m_rgchConnectString);",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ulBeaconID;\n    CSteamID m_SteamIDBeaconOwner;\n    char m_rgchConnectString[256];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBeaconID",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_SteamIDBeaconOwner",
+     0
+    ],
+    [
+     "char",
+     "m_rgchConnectString",
+     256
+    ]
+   ],
    "pack": 8
   },
   "w32_LeaderboardEntry_t_104": {
    "body": "    CSteamID m_steamIDUser;\n    int32_t m_nGlobalRank;\n    int32_t m_nScore;\n    int32_t m_cDetails;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRank",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cDetails",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_LeaderboardEntry_t_111x": {
    "body": "    CSteamID m_steamIDUser;\n    int32_t m_nGlobalRank;\n    int32_t m_nScore;\n    int32_t m_cDetails;\n    uint8_t __pad_20[4];\n    uint64_t m_hUGC;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRank",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cDetails",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hUGC",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_LeaderboardEntry_t_123": {
    "body": "    CSteamID m_steamIDUser;\n    int32_t m_nGlobalRank;\n    int32_t m_nScore;\n    int32_t m_cDetails;\n    uint8_t __pad_20[4];\n    uint64_t m_hUGC;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRank",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cDetails",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hUGC",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_LeaderboardScoreUploaded_t_104": {
    "body": "    uint8_t m_bSuccess;\n    uint8_t __pad_1[7];\n    uint64_t m_hSteamLeaderboard;\n    int32_t m_nScore;\n    uint8_t m_bScoreChanged;\n    uint8_t __pad_21[3];\n    int32_t m_nGlobalRankNew;\n    int32_t m_nGlobalRankPrevious;",
+   "fields": [
+    [
+     "uint8_t",
+     "m_bSuccess",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bScoreChanged",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRankNew",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRankPrevious",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_LeaderboardScoreUploaded_t_123": {
    "body": "    uint8_t m_bSuccess;\n    uint8_t __pad_1[7];\n    uint64_t m_hSteamLeaderboard;\n    int32_t m_nScore;\n    uint8_t m_bScoreChanged;\n    uint8_t __pad_21[3];\n    int32_t m_nGlobalRankNew;\n    int32_t m_nGlobalRankPrevious;",
+   "fields": [
+    [
+     "uint8_t",
+     "m_bSuccess",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bScoreChanged",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRankNew",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRankPrevious",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_LeaderboardUGCSet_t_111x": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hSteamLeaderboard;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_LeaderboardUGCSet_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hSteamLeaderboard;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_LobbyCreated_t_099u": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ulSteamIDLobby;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_LobbyCreated_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ulSteamIDLobby;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_MicroTxnAuthorizationResponse_t_109": {
    "body": "    uint32_t m_unAppID;\n    uint8_t __pad_4[4];\n    uint64_t m_ulOrderID;\n    uint8_t m_bAuthorized;\n    uint8_t __pad_17[7];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulOrderID",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bAuthorized",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_MicroTxnAuthorizationResponse_t_123": {
    "body": "    uint32_t m_unAppID;\n    uint8_t __pad_4[4];\n    uint64_t m_ulOrderID;\n    uint8_t m_bAuthorized;\n    uint8_t __pad_17[7];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulOrderID",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bAuthorized",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_PS3TrophiesInstalled_t_112x": {
    "body": "    uint64_t m_nGameID;\n    uint32_t m_eResult;\n    uint8_t __pad_12[4];\n    uint64_t m_ulRequiredDiskSpace;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulRequiredDiskSpace",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_PS3TrophiesInstalled_t_123": {
    "body": "    uint64_t m_nGameID;\n    uint32_t m_eResult;\n    uint8_t __pad_12[4];\n    uint64_t m_ulRequiredDiskSpace;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulRequiredDiskSpace",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageAppSyncProgress_t_111x": {
-   "body": "    W32_ARRAY(char, 260, m_rgchCurrentFile);\n    uint32_t m_nAppID;\n    uint32_t m_uBytesTransferredThisChunk;\n    uint8_t __pad_268[4];\n    double m_dAppPercentComplete;\n    int8_t m_bUploading;\n    uint8_t __pad_281[7];",
+   "body": "    char m_rgchCurrentFile[260];\n    uint32_t m_nAppID;\n    uint32_t m_uBytesTransferredThisChunk;\n    uint8_t __pad_268[4];\n    double m_dAppPercentComplete;\n    int8_t m_bUploading;\n    uint8_t __pad_281[7];",
+   "fields": [
+    [
+     "char",
+     "m_rgchCurrentFile",
+     260
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_uBytesTransferredThisChunk",
+     0
+    ],
+    [
+     "double",
+     "m_dAppPercentComplete",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUploading",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageAppSyncProgress_t_123": {
-   "body": "    W32_ARRAY(char, 260, m_rgchCurrentFile);\n    uint32_t m_nAppID;\n    uint32_t m_uBytesTransferredThisChunk;\n    uint8_t __pad_268[4];\n    double m_dAppPercentComplete;\n    int8_t m_bUploading;\n    uint8_t __pad_281[7];",
+   "body": "    char m_rgchCurrentFile[260];\n    uint32_t m_nAppID;\n    uint32_t m_uBytesTransferredThisChunk;\n    uint8_t __pad_268[4];\n    double m_dAppPercentComplete;\n    int8_t m_bUploading;\n    uint8_t __pad_281[7];",
+   "fields": [
+    [
+     "char",
+     "m_rgchCurrentFile",
+     260
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_uBytesTransferredThisChunk",
+     0
+    ],
+    [
+     "double",
+     "m_dAppPercentComplete",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUploading",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageDeletePublishedFileResult_t_116x": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageDeletePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageDownloadUGCResult_t_111x": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    char *m_pchFileName;\n    uint8_t __pad_28[4];\n    uint64_t m_ulSteamIDOwner;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSizeInBytes",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageDownloadUGCResult_t_116x": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    W32_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_284[4];\n    uint64_t m_ulSteamIDOwner;",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    char m_pchFileName[260];\n    uint8_t __pad_284[4];\n    uint64_t m_ulSteamIDOwner;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSizeInBytes",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageDownloadUGCResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    W32_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_284[4];\n    uint64_t m_ulSteamIDOwner;",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    char m_pchFileName[260];\n    uint8_t __pad_284[4];\n    uint64_t m_ulSteamIDOwner;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSizeInBytes",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageEnumerateUserPublishedFilesResult_t_116x": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W32_ARRAY(uint64_t, 50, m_rgPublishedFileId);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageEnumerateUserPublishedFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W32_ARRAY(uint64_t, 50, m_rgPublishedFileId);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageEnumerateUserSharedWorkshopFilesResult_t_119": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W32_ARRAY(uint64_t, 50, m_rgPublishedFileId);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageEnumerateUserSharedWorkshopFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W32_ARRAY(uint64_t, 50, m_rgPublishedFileId);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageEnumerateUserSubscribedFilesResult_t_116x": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W32_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    W32_ARRAY(uint32_t, 50, m_rgRTimeSubscribed);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];\n    uint32_t m_rgRTimeSubscribed[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "uint32_t",
+     "m_rgRTimeSubscribed",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageEnumerateUserSubscribedFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W32_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    W32_ARRAY(uint32_t, 50, m_rgRTimeSubscribed);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];\n    uint32_t m_rgRTimeSubscribed[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "uint32_t",
+     "m_rgRTimeSubscribed",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageEnumerateWorkshopFilesResult_t_119": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W32_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    W32_ARRAY(float, 50, m_rgScore);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];\n    float m_rgScore[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "float",
+     "m_rgScore",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageEnumerateWorkshopFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W32_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    W32_ARRAY(float, 50, m_rgScore);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];\n    float m_rgScore[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "float",
+     "m_rgScore",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageEnumerateWorkshopFilesResult_t_125": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W32_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    W32_ARRAY(float, 50, m_rgScore);\n    uint32_t m_nAppId;\n    uint32_t m_unStartIndex;",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];\n    float m_rgScore[50];\n    uint32_t m_nAppId;\n    uint32_t m_unStartIndex;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "float",
+     "m_rgScore",
+     50
+    ],
+    [
+     "uint32_t",
+     "m_nAppId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unStartIndex",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageFileShareResult_t_111x": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageFileShareResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageFileShareResult_t_128x": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;\n    W32_ARRAY(char, 260, m_rgchFilename);\n    uint8_t __pad_276[4];",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;\n    char m_rgchFilename[260];\n    uint8_t __pad_276[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "char",
+     "m_rgchFilename",
+     260
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageGetPublishedFileDetailsResult_t_116x": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W32_ARRAY(char, 129, m_rgchTitle);\n    W32_ARRAY(char, 257, m_rgchDescription);\n    uint8_t __pad_410[6];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    W32_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    W32_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_1739[5];",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[257];\n    uint8_t __pad_410[6];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_1739[5];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     257
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageGetPublishedFileDetailsResult_t_118": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W32_ARRAY(char, 129, m_rgchTitle);\n    W32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    W32_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    W32_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    uint8_t __pad_9492[4];",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    uint8_t __pad_9492[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageGetPublishedFileDetailsResult_t_119": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W32_ARRAY(char, 129, m_rgchTitle);\n    W32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    W32_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    W32_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    W32_ARRAY(char, 256, m_rgchURL);\n    uint8_t __pad_9748[4];",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint8_t __pad_9748[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageGetPublishedFileDetailsResult_t_119x": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W32_ARRAY(char, 129, m_rgchTitle);\n    W32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    W32_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    W32_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    W32_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_eFileType;",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_eFileType;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageGetPublishedFileDetailsResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W32_ARRAY(char, 129, m_rgchTitle);\n    W32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    W32_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    W32_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    W32_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_eFileType;",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_eFileType;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageGetPublishedFileDetailsResult_t_126": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W32_ARRAY(char, 129, m_rgchTitle);\n    W32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    W32_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    W32_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    W32_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_eFileType;\n    int8_t m_bAcceptedForUse;\n    uint8_t __pad_9753[7];",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_eFileType;\n    int8_t m_bAcceptedForUse;\n    uint8_t __pad_9753[7];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageGetPublishedItemVoteDetailsResult_t_119": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_unPublishedFileId;\n    int32_t m_nVotesFor;\n    int32_t m_nVotesAgainst;\n    int32_t m_nReports;\n    float m_fScore;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_unPublishedFileId",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nVotesFor",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nVotesAgainst",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nReports",
+     0
+    ],
+    [
+     "float",
+     "m_fScore",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageGetPublishedItemVoteDetailsResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_unPublishedFileId;\n    int32_t m_nVotesFor;\n    int32_t m_nVotesAgainst;\n    int32_t m_nReports;\n    float m_fScore;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_unPublishedFileId",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nVotesFor",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nVotesAgainst",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nReports",
+     0
+    ],
+    [
+     "float",
+     "m_fScore",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStoragePublishFileResult_t_116x": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStoragePublishFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStoragePublishFileResult_t_125": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    int8_t m_bUserNeedsToAcceptWorkshopLegalAgreement;\n    uint8_t __pad_17[7];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserNeedsToAcceptWorkshopLegalAgreement",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStoragePublishedFileUpdated_t": {
    "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;\n    uint8_t __pad_12[4];\n    uint64_t m_ulUnused;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulUnused",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageSetUserPublishedFileActionResult_t_119": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eAction;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eAction",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageSetUserPublishedFileActionResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eAction;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eAction",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageSubscribePublishedFileResult_t_116x": {
    "body": "    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_RemoteStorageSubscribePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageUnsubscribePublishedFileResult_t_116x": {
    "body": "    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_RemoteStorageUnsubscribePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageUpdatePublishedFileRequest_t": {
    "body": "    uint64_t m_unPublishedFileId;\n    const char *m_pchFile;\n    const char *m_pchPreviewFile;\n    const char *m_pchTitle;\n    const char *m_pchDescription;\n    uint32_t m_eVisibility;\n    w32_SteamParamStringArray_t *m_pTags;\n    int8_t m_bUpdateFile;\n    int8_t m_bUpdatePreviewFile;\n    int8_t m_bUpdateTitle;\n    int8_t m_bUpdateDescription;\n    int8_t m_bUpdateVisibility;\n    int8_t m_bUpdateTags;\n    uint8_t __pad_38[2];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_unPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUpdateFile",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUpdatePreviewFile",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUpdateTitle",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUpdateDescription",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUpdateVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUpdateTags",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageUpdatePublishedFileResult_t_116x": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageUpdatePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageUpdatePublishedFileResult_t_125": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    int8_t m_bUserNeedsToAcceptWorkshopLegalAgreement;\n    uint8_t __pad_17[7];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserNeedsToAcceptWorkshopLegalAgreement",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageUpdateUserPublishedItemVoteResult_t_119": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageUpdateUserPublishedItemVoteResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageUserVoteDetails_t_119": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eVote;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVote",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoteStorageUserVoteDetails_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eVote;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVote",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoveAppDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RemoveUGCDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint64_t m_nChildPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nChildPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RequestPlayersForGameFinalResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ullSearchID;\n    uint64_t m_ullUniqueGameID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullSearchID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullUniqueGameID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RequestPlayersForGameProgressCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ullSearchID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullSearchID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_RequestPlayersForGameResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ullSearchID;\n    CSteamID m_SteamIDPlayerFound;\n    CSteamID m_SteamIDLobby;\n    uint32_t m_ePlayerAcceptState;\n    int32_t m_nPlayerIndex;\n    int32_t m_nTotalPlayersFound;\n    int32_t m_nTotalPlayersAcceptedGame;\n    int32_t m_nSuggestedTeamIndex;\n    uint8_t __pad_52[4];\n    uint64_t m_ullUniqueGameID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullSearchID",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_SteamIDPlayerFound",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_SteamIDLobby",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_ePlayerAcceptState",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPlayerIndex",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalPlayersFound",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalPlayersAcceptedGame",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSuggestedTeamIndex",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullUniqueGameID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamInputConfigurationLoaded_t": {
    "body": "    uint32_t m_unAppID;\n    uint8_t __pad_4[4];\n    uint64_t m_ulDeviceHandle;\n    CSteamID m_ulMappingCreator;\n    uint32_t m_unMajorRevision;\n    uint32_t m_unMinorRevision;\n    int8_t m_bUsesSteamInputAPI;\n    int8_t m_bUsesGamepadAPI;\n    uint8_t __pad_34[6];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulDeviceHandle",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_ulMappingCreator",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unMajorRevision",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unMinorRevision",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUsesSteamInputAPI",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUsesGamepadAPI",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamInputGamepadSlotChange_t": {
    "body": "    uint32_t m_unAppID;\n    uint8_t __pad_4[4];\n    uint64_t m_ulDeviceHandle;\n    uint32_t m_eDeviceType;\n    int32_t m_nOldGamepadSlot;\n    int32_t m_nNewGamepadSlot;\n    uint8_t __pad_28[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulDeviceHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eDeviceType",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nOldGamepadSlot",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nNewGamepadSlot",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamInventoryStartPurchaseResult_t": {
    "body": "    uint32_t m_result;\n    uint8_t __pad_4[4];\n    uint64_t m_ulOrderID;\n    uint64_t m_ulTransID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_result",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulOrderID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulTransID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamNetConnectionStatusChangedCallback_t_144": {
    "body": "    uint32_t m_hConn;\n    uint8_t __pad_4[4];\n    SteamNetConnectionInfo_t_144 m_info;\n    uint32_t m_eOldState;\n    uint8_t __pad_708[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hConn",
+     0
+    ],
+    [
+     "SteamNetConnectionInfo_t_144",
+     "m_info",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eOldState",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamNetConnectionStatusChangedCallback_t_151": {
    "body": "    uint32_t m_hConn;\n    uint8_t __pad_4[4];\n    SteamNetConnectionInfo_t_151 m_info;\n    uint32_t m_eOldState;\n    uint8_t __pad_580[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hConn",
+     0
+    ],
+    [
+     "SteamNetConnectionInfo_t_151",
+     "m_info",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eOldState",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamNetConnectionStatusChangedCallback_t_153a": {
    "body": "    uint32_t m_hConn;\n    uint8_t __pad_4[4];\n    SteamNetConnectionInfo_t_153a m_info;\n    uint32_t m_eOldState;\n    uint8_t __pad_708[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hConn",
+     0
+    ],
+    [
+     "SteamNetConnectionInfo_t_153a",
+     "m_info",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eOldState",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamNetworkingMessage_t_144": {
    "body": "    void *m_pData;\n    uint32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_144 m_sender;\n    uint8_t __pad_148[4];\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*W_CDECL m_pfnFreeData)(w32_SteamNetworkingMessage_t_144 *);\n    void (*W_CDECL m_pfnRelease)(w32_SteamNetworkingMessage_t_144 *);\n    int32_t m_nChannel;\n    int32_t m___nPadDummy;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_144",
+     "m_sender",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m___nPadDummy",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamNetworkingMessage_t_147": {
    "body": "    void *m_pData;\n    int32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_144 m_identityPeer;\n    uint8_t __pad_148[4];\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*W_CDECL m_pfnFreeData)(w32_SteamNetworkingMessage_t_147 *);\n    void (*W_CDECL m_pfnRelease)(w32_SteamNetworkingMessage_t_147 *);\n    int32_t m_nChannel;\n    int32_t m_nFlags;\n    int64_t m_nUserData;",
+   "fields": [
+    [
+     "int32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_144",
+     "m_identityPeer",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nFlags",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamNetworkingMessage_t_151": {
    "body": "    void *m_pData;\n    int32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_151 m_identityPeer;\n    uint8_t __pad_20[4];\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*W_CDECL m_pfnFreeData)(w32_SteamNetworkingMessage_t_151 *);\n    void (*W_CDECL m_pfnRelease)(w32_SteamNetworkingMessage_t_151 *);\n    int32_t m_nChannel;\n    int32_t m_nFlags;\n    int64_t m_nUserData;",
+   "fields": [
+    [
+     "int32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_151",
+     "m_identityPeer",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nFlags",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamNetworkingMessage_t_153a": {
    "body": "    void *m_pData;\n    int32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_144 m_identityPeer;\n    uint8_t __pad_148[4];\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*W_CDECL m_pfnFreeData)(w32_SteamNetworkingMessage_t_153a *);\n    void (*W_CDECL m_pfnRelease)(w32_SteamNetworkingMessage_t_153a *);\n    int32_t m_nChannel;\n    int32_t m_nFlags;\n    int64_t m_nUserData;\n    uint16_t m_idxLane;\n    uint16_t _pad1__;\n    uint8_t __pad_204[4];",
+   "fields": [
+    [
+     "int32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_144",
+     "m_identityPeer",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nFlags",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_idxLane",
+     0
+    ],
+    [
+     "uint16_t",
+     "_pad1__",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamParamStringArray_t": {
    "body": "    const char **m_ppStrings;\n    int32_t m_nNumStrings;",
+   "fields": [
+    [
+     "int32_t",
+     "m_nNumStrings",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w32_SteamPartyBeaconLocation_t": {
    "body": "    uint32_t m_eType;\n    uint8_t __pad_4[4];\n    uint64_t m_ulLocationID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eType",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulLocationID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamUGCDetails_t_126": {
-   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W32_ARRAY(char, 129, m_rgchTitle);\n    W32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    W32_ARRAY(char, 1025, m_rgchTags);\n    uint8_t __pad_9212[4];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    W32_ARRAY(char, 260, m_pchFileName);\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    W32_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;",
+   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    char m_rgchTags[1025];\n    uint8_t __pad_9212[4];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    char m_pchFileName[260];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeAddedToUserList",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_unVotesUp",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVotesDown",
+     0
+    ],
+    [
+     "float",
+     "m_flScore",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamUGCDetails_t_128x": {
-   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W32_ARRAY(char, 129, m_rgchTitle);\n    W32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    W32_ARRAY(char, 1025, m_rgchTags);\n    uint8_t __pad_9212[4];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    W32_ARRAY(char, 260, m_pchFileName);\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    W32_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;\n    uint8_t __pad_9772[4];",
+   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    char m_rgchTags[1025];\n    uint8_t __pad_9212[4];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    char m_pchFileName[260];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;\n    uint8_t __pad_9772[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeAddedToUserList",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_unVotesUp",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVotesDown",
+     0
+    ],
+    [
+     "float",
+     "m_flScore",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unNumChildren",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamUGCDetails_t_160": {
-   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W32_ARRAY(char, 129, m_rgchTitle);\n    W32_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    W32_ARRAY(char, 1025, m_rgchTags);\n    uint8_t __pad_9212[4];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    W32_ARRAY(char, 260, m_pchFileName);\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    W32_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;\n    uint8_t __pad_9772[4];\n    uint64_t m_ulTotalFilesSize;",
+   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    char m_rgchTags[1025];\n    uint8_t __pad_9212[4];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    char m_pchFileName[260];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;\n    uint8_t __pad_9772[4];\n    uint64_t m_ulTotalFilesSize;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeAddedToUserList",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_unVotesUp",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVotesDown",
+     0
+    ],
+    [
+     "float",
+     "m_flScore",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unNumChildren",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulTotalFilesSize",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamUGCRequestUGCDetailsResult_t_126": {
    "body": "    w32_SteamUGCDetails_t_126 m_details;",
+   "fields": [
+    [
+     "w32_SteamUGCDetails_t_126",
+     "m_details",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamUGCRequestUGCDetailsResult_t_128x": {
    "body": "    w32_SteamUGCDetails_t_128x m_details;\n    int8_t m_bCachedData;\n    uint8_t __pad_9777[7];",
+   "fields": [
+    [
+     "w32_SteamUGCDetails_t_128x",
+     "m_details",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamUGCRequestUGCDetailsResult_t_129": {
    "body": "    w32_SteamUGCDetails_t_126 m_details;\n    int8_t m_bCachedData;\n    uint8_t __pad_9769[7];",
+   "fields": [
+    [
+     "w32_SteamUGCDetails_t_126",
+     "m_details",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SteamUGCRequestUGCDetailsResult_t_160": {
    "body": "    w32_SteamUGCDetails_t_160 m_details;\n    int8_t m_bCachedData;\n    uint8_t __pad_9785[7];",
+   "fields": [
+    [
+     "w32_SteamUGCDetails_t_160",
+     "m_details",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w32_SubmitPlayerResultResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t ullUniqueGameID;\n    CSteamID steamIDPlayer;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "ullUniqueGameID",
+     0
+    ],
+    [
+     "CSteamID",
+     "steamIDPlayer",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_AddAppDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_AddUGCDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint64_t m_nChildPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nChildPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_CallbackMsg_t": {
    "body": "    int32_t m_hSteamUser;\n    int32_t m_iCallback;\n    uint8_t *m_pubParam;\n    int32_t m_cubParam;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "int32_t",
+     "m_hSteamUser",
+     0
+    ],
+    [
+     "int32_t",
+     "m_iCallback",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cubParam",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_CreateBeaconCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ulBeaconID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBeaconID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_CreateItemResult_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    int8_t m_bUserNeedsToAcceptWorkshopLegalAgreement;\n    uint8_t __pad_17[7];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserNeedsToAcceptWorkshopLegalAgreement",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_DeleteItemResult_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_DownloadItemResult_t": {
    "body": "    uint32_t m_unAppID;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_EndGameResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t ullUniqueGameID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "ullUniqueGameID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_FileDetailsResult_t": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ulFileSize;\n    W64_ARRAY(uint8_t, 20, m_FileSHA);\n    uint32_t m_unFlags;",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ulFileSize;\n    uint8_t m_FileSHA[20];\n    uint32_t m_unFlags;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulFileSize",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_FileSHA",
+     20
+    ],
+    [
+     "uint32_t",
+     "m_unFlags",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_GSReputation_t_108": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_unReputationScore;\n    int8_t m_bBanned;\n    uint8_t __pad_9[3];\n    uint32_t m_unBannedIP;\n    uint16_t m_usBannedPort;\n    uint8_t __pad_18[6];\n    uint64_t m_ulBannedGameID;\n    uint32_t m_unBanExpires;\n    uint8_t __pad_36[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unReputationScore",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBannedIP",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_usBannedPort",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBannedGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBanExpires",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_GSReputation_t_123": {
    "body": "    uint32_t m_eResult;\n    uint32_t m_unReputationScore;\n    int8_t m_bBanned;\n    uint8_t __pad_9[3];\n    uint32_t m_unBannedIP;\n    uint16_t m_usBannedPort;\n    uint8_t __pad_18[6];\n    uint64_t m_ulBannedGameID;\n    uint32_t m_unBanExpires;\n    uint8_t __pad_36[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unReputationScore",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBannedIP",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_usBannedPort",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBannedGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBanExpires",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_GetAppDependenciesResult_t": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    W64_ARRAY(uint32_t, 32, m_rgAppIDs);\n    uint32_t m_nNumAppDependencies;\n    uint32_t m_nTotalNumAppDependencies;",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_rgAppIDs[32];\n    uint32_t m_nNumAppDependencies;\n    uint32_t m_nTotalNumAppDependencies;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rgAppIDs",
+     32
+    ],
+    [
+     "uint32_t",
+     "m_nNumAppDependencies",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nTotalNumAppDependencies",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_ChangedTitle_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pchTitle;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_ComboNeedsPaint_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pBGRA;\n    uint32_t unWide;\n    uint32_t unTall;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_FileOpenDialog_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pchTitle;\n    const char *pchInitialFile;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_FinishedRequest_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pchURL;\n    const char *pchPageTitle;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_JSAlert_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pchMessage;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_JSConfirm_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pchMessage;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_LinkAtPosition_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint32_t x;\n    uint32_t y;\n    uint8_t __pad_12[4];\n    const char *pchURL;\n    int8_t bInput;\n    int8_t bLiveLink;\n    uint8_t __pad_26[6];",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "x",
+     0
+    ],
+    [
+     "uint32_t",
+     "y",
+     0
+    ],
+    [
+     "int8_t",
+     "bInput",
+     0
+    ],
+    [
+     "int8_t",
+     "bLiveLink",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_NeedsPaint_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pBGRA;\n    uint32_t unWide;\n    uint32_t unTall;\n    uint32_t unUpdateX;\n    uint32_t unUpdateY;\n    uint32_t unUpdateWide;\n    uint32_t unUpdateTall;\n    uint32_t unScrollX;\n    uint32_t unScrollY;\n    float flPageScale;\n    uint32_t unPageSerial;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ],
+    [
+     "uint32_t",
+     "unUpdateX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unUpdateY",
+     0
+    ],
+    [
+     "uint32_t",
+     "unUpdateWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unUpdateTall",
+     0
+    ],
+    [
+     "uint32_t",
+     "unScrollX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unScrollY",
+     0
+    ],
+    [
+     "float",
+     "flPageScale",
+     0
+    ],
+    [
+     "uint32_t",
+     "unPageSerial",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_NewWindow_t_130x": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pchURL;\n    uint32_t unX;\n    uint32_t unY;\n    uint32_t unWide;\n    uint32_t unTall;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unY",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_NewWindow_t_132x": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pchURL;\n    uint32_t unX;\n    uint32_t unY;\n    uint32_t unWide;\n    uint32_t unTall;\n    uint32_t unNewWindow_BrowserHandle_IGNORE;\n    uint8_t __pad_36[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "unX",
+     0
+    ],
+    [
+     "uint32_t",
+     "unY",
+     0
+    ],
+    [
+     "uint32_t",
+     "unWide",
+     0
+    ],
+    [
+     "uint32_t",
+     "unTall",
+     0
+    ],
+    [
+     "uint32_t",
+     "unNewWindow_BrowserHandle_IGNORE",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_OpenLinkInNewTab_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pchURL;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_ShowToolTip_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pchMsg;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_StartRequest_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pchURL;\n    const char *pchTarget;\n    const char *pchPostData;\n    int8_t bIsRedirect;\n    uint8_t __pad_33[7];",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "int8_t",
+     "bIsRedirect",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_StatusText_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pchMsg;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_URLChanged_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pchURL;\n    const char *pchPostData;\n    int8_t bIsRedirect;\n    uint8_t __pad_25[7];\n    const char *pchPageTitle;\n    int8_t bNewNavigation;\n    uint8_t __pad_41[7];",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ],
+    [
+     "int8_t",
+     "bIsRedirect",
+     0
+    ],
+    [
+     "int8_t",
+     "bNewNavigation",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTML_UpdateToolTip_t": {
    "body": "    uint32_t unBrowserHandle;\n    uint8_t __pad_4[4];\n    const char *pchMsg;",
+   "fields": [
+    [
+     "uint32_t",
+     "unBrowserHandle",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTTPRequestCompleted_t_115": {
    "body": "    uint32_t m_hRequest;\n    uint8_t __pad_4[4];\n    uint64_t m_ulContextValue;\n    int8_t m_bRequestSuccessful;\n    uint8_t __pad_17[3];\n    uint32_t m_eStatusCode;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bRequestSuccessful",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eStatusCode",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTTPRequestCompleted_t_123": {
    "body": "    uint32_t m_hRequest;\n    uint8_t __pad_4[4];\n    uint64_t m_ulContextValue;\n    int8_t m_bRequestSuccessful;\n    uint8_t __pad_17[3];\n    uint32_t m_eStatusCode;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bRequestSuccessful",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eStatusCode",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTTPRequestCompleted_t_132x": {
    "body": "    uint32_t m_hRequest;\n    uint8_t __pad_4[4];\n    uint64_t m_ulContextValue;\n    int8_t m_bRequestSuccessful;\n    uint8_t __pad_17[3];\n    uint32_t m_eStatusCode;\n    uint32_t m_unBodySize;\n    uint8_t __pad_28[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bRequestSuccessful",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eStatusCode",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unBodySize",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTTPRequestDataReceived_t_121x": {
    "body": "    uint32_t m_hRequest;\n    uint8_t __pad_4[4];\n    uint64_t m_ulContextValue;\n    uint32_t m_cOffset;\n    uint32_t m_cBytesReceived;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cOffset",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cBytesReceived",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTTPRequestDataReceived_t_123": {
    "body": "    uint32_t m_hRequest;\n    uint8_t __pad_4[4];\n    uint64_t m_ulContextValue;\n    uint32_t m_cOffset;\n    uint32_t m_cBytesReceived;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cOffset",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_cBytesReceived",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTTPRequestHeadersReceived_t_121x": {
    "body": "    uint32_t m_hRequest;\n    uint8_t __pad_4[4];\n    uint64_t m_ulContextValue;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_HTTPRequestHeadersReceived_t_123": {
    "body": "    uint32_t m_hRequest;\n    uint8_t __pad_4[4];\n    uint64_t m_ulContextValue;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hRequest",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulContextValue",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_ItemInstalled_t_130": {
    "body": "    uint32_t m_unAppID;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_ItemInstalled_t_160": {
    "body": "    uint32_t m_unAppID;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint64_t m_hLegacyContent;\n    uint64_t m_unManifestID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hLegacyContent",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_unManifestID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_JoinPartyCallback_t": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ulBeaconID;\n    CSteamID m_SteamIDBeaconOwner;\n    W64_ARRAY(char, 256, m_rgchConnectString);",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ulBeaconID;\n    CSteamID m_SteamIDBeaconOwner;\n    char m_rgchConnectString[256];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulBeaconID",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_SteamIDBeaconOwner",
+     0
+    ],
+    [
+     "char",
+     "m_rgchConnectString",
+     256
+    ]
+   ],
    "pack": 8
   },
   "w64_LeaderboardEntry_t_104": {
    "body": "    CSteamID m_steamIDUser;\n    int32_t m_nGlobalRank;\n    int32_t m_nScore;\n    int32_t m_cDetails;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRank",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cDetails",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w64_LeaderboardEntry_t_111x": {
    "body": "    CSteamID m_steamIDUser;\n    int32_t m_nGlobalRank;\n    int32_t m_nScore;\n    int32_t m_cDetails;\n    uint8_t __pad_20[4];\n    uint64_t m_hUGC;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRank",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cDetails",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hUGC",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_LeaderboardEntry_t_123": {
    "body": "    CSteamID m_steamIDUser;\n    int32_t m_nGlobalRank;\n    int32_t m_nScore;\n    int32_t m_cDetails;\n    uint8_t __pad_20[4];\n    uint64_t m_hUGC;",
+   "fields": [
+    [
+     "CSteamID",
+     "m_steamIDUser",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRank",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "int32_t",
+     "m_cDetails",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hUGC",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_LeaderboardScoreUploaded_t_104": {
    "body": "    uint8_t m_bSuccess;\n    uint8_t __pad_1[7];\n    uint64_t m_hSteamLeaderboard;\n    int32_t m_nScore;\n    uint8_t m_bScoreChanged;\n    uint8_t __pad_21[3];\n    int32_t m_nGlobalRankNew;\n    int32_t m_nGlobalRankPrevious;",
+   "fields": [
+    [
+     "uint8_t",
+     "m_bSuccess",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bScoreChanged",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRankNew",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRankPrevious",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_LeaderboardScoreUploaded_t_123": {
    "body": "    uint8_t m_bSuccess;\n    uint8_t __pad_1[7];\n    uint64_t m_hSteamLeaderboard;\n    int32_t m_nScore;\n    uint8_t m_bScoreChanged;\n    uint8_t __pad_21[3];\n    int32_t m_nGlobalRankNew;\n    int32_t m_nGlobalRankPrevious;",
+   "fields": [
+    [
+     "uint8_t",
+     "m_bSuccess",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nScore",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bScoreChanged",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRankNew",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nGlobalRankPrevious",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_LeaderboardUGCSet_t_111x": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hSteamLeaderboard;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_LeaderboardUGCSet_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hSteamLeaderboard;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hSteamLeaderboard",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_LobbyCreated_t_099u": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ulSteamIDLobby;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_LobbyCreated_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ulSteamIDLobby;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDLobby",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_MicroTxnAuthorizationResponse_t_109": {
    "body": "    uint32_t m_unAppID;\n    uint8_t __pad_4[4];\n    uint64_t m_ulOrderID;\n    uint8_t m_bAuthorized;\n    uint8_t __pad_17[7];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulOrderID",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bAuthorized",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_MicroTxnAuthorizationResponse_t_123": {
    "body": "    uint32_t m_unAppID;\n    uint8_t __pad_4[4];\n    uint64_t m_ulOrderID;\n    uint8_t m_bAuthorized;\n    uint8_t __pad_17[7];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulOrderID",
+     0
+    ],
+    [
+     "uint8_t",
+     "m_bAuthorized",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_PS3TrophiesInstalled_t_112x": {
    "body": "    uint64_t m_nGameID;\n    uint32_t m_eResult;\n    uint8_t __pad_12[4];\n    uint64_t m_ulRequiredDiskSpace;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulRequiredDiskSpace",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_PS3TrophiesInstalled_t_123": {
    "body": "    uint64_t m_nGameID;\n    uint32_t m_eResult;\n    uint8_t __pad_12[4];\n    uint64_t m_ulRequiredDiskSpace;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nGameID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulRequiredDiskSpace",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageAppSyncProgress_t_111x": {
-   "body": "    W64_ARRAY(char, 260, m_rgchCurrentFile);\n    uint32_t m_nAppID;\n    uint32_t m_uBytesTransferredThisChunk;\n    uint8_t __pad_268[4];\n    double m_dAppPercentComplete;\n    int8_t m_bUploading;\n    uint8_t __pad_281[7];",
+   "body": "    char m_rgchCurrentFile[260];\n    uint32_t m_nAppID;\n    uint32_t m_uBytesTransferredThisChunk;\n    uint8_t __pad_268[4];\n    double m_dAppPercentComplete;\n    int8_t m_bUploading;\n    uint8_t __pad_281[7];",
+   "fields": [
+    [
+     "char",
+     "m_rgchCurrentFile",
+     260
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_uBytesTransferredThisChunk",
+     0
+    ],
+    [
+     "double",
+     "m_dAppPercentComplete",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUploading",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageAppSyncProgress_t_123": {
-   "body": "    W64_ARRAY(char, 260, m_rgchCurrentFile);\n    uint32_t m_nAppID;\n    uint32_t m_uBytesTransferredThisChunk;\n    uint8_t __pad_268[4];\n    double m_dAppPercentComplete;\n    int8_t m_bUploading;\n    uint8_t __pad_281[7];",
+   "body": "    char m_rgchCurrentFile[260];\n    uint32_t m_nAppID;\n    uint32_t m_uBytesTransferredThisChunk;\n    uint8_t __pad_268[4];\n    double m_dAppPercentComplete;\n    int8_t m_bUploading;\n    uint8_t __pad_281[7];",
+   "fields": [
+    [
+     "char",
+     "m_rgchCurrentFile",
+     260
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_uBytesTransferredThisChunk",
+     0
+    ],
+    [
+     "double",
+     "m_dAppPercentComplete",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUploading",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageDeletePublishedFileResult_t_116x": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageDeletePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageDownloadUGCResult_t_111x": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    char *m_pchFileName;\n    uint64_t m_ulSteamIDOwner;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSizeInBytes",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageDownloadUGCResult_t_116x": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    W64_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_284[4];\n    uint64_t m_ulSteamIDOwner;",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    char m_pchFileName[260];\n    uint8_t __pad_284[4];\n    uint64_t m_ulSteamIDOwner;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSizeInBytes",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageDownloadUGCResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    W64_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_284[4];\n    uint64_t m_ulSteamIDOwner;",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;\n    uint32_t m_nAppID;\n    int32_t m_nSizeInBytes;\n    char m_pchFileName[260];\n    uint8_t __pad_284[4];\n    uint64_t m_ulSteamIDOwner;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSizeInBytes",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageEnumerateUserPublishedFilesResult_t_116x": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W64_ARRAY(uint64_t, 50, m_rgPublishedFileId);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageEnumerateUserPublishedFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W64_ARRAY(uint64_t, 50, m_rgPublishedFileId);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageEnumerateUserSharedWorkshopFilesResult_t_119": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W64_ARRAY(uint64_t, 50, m_rgPublishedFileId);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageEnumerateUserSharedWorkshopFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W64_ARRAY(uint64_t, 50, m_rgPublishedFileId);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageEnumerateUserSubscribedFilesResult_t_116x": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W64_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    W64_ARRAY(uint32_t, 50, m_rgRTimeSubscribed);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];\n    uint32_t m_rgRTimeSubscribed[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "uint32_t",
+     "m_rgRTimeSubscribed",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageEnumerateUserSubscribedFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W64_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    W64_ARRAY(uint32_t, 50, m_rgRTimeSubscribed);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];\n    uint32_t m_rgRTimeSubscribed[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "uint32_t",
+     "m_rgRTimeSubscribed",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageEnumerateWorkshopFilesResult_t_119": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W64_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    W64_ARRAY(float, 50, m_rgScore);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];\n    float m_rgScore[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "float",
+     "m_rgScore",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageEnumerateWorkshopFilesResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W64_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    W64_ARRAY(float, 50, m_rgScore);",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];\n    float m_rgScore[50];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "float",
+     "m_rgScore",
+     50
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageEnumerateWorkshopFilesResult_t_125": {
-   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    W64_ARRAY(uint64_t, 50, m_rgPublishedFileId);\n    W64_ARRAY(float, 50, m_rgScore);\n    uint32_t m_nAppId;\n    uint32_t m_unStartIndex;",
+   "body": "    uint32_t m_eResult;\n    int32_t m_nResultsReturned;\n    int32_t m_nTotalResultCount;\n    uint8_t __pad_12[4];\n    uint64_t m_rgPublishedFileId[50];\n    float m_rgScore[50];\n    uint32_t m_nAppId;\n    uint32_t m_unStartIndex;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nResultsReturned",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalResultCount",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_rgPublishedFileId",
+     50
+    ],
+    [
+     "float",
+     "m_rgScore",
+     50
+    ],
+    [
+     "uint32_t",
+     "m_nAppId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unStartIndex",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageFileShareResult_t_111x": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageFileShareResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageFileShareResult_t_128x": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;\n    W64_ARRAY(char, 260, m_rgchFilename);\n    uint8_t __pad_276[4];",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_hFile;\n    char m_rgchFilename[260];\n    uint8_t __pad_276[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "char",
+     "m_rgchFilename",
+     260
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageGetPublishedFileDetailsResult_t_116x": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W64_ARRAY(char, 129, m_rgchTitle);\n    W64_ARRAY(char, 257, m_rgchDescription);\n    uint8_t __pad_410[6];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    W64_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    W64_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_1739[5];",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[257];\n    uint8_t __pad_410[6];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_1739[5];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     257
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageGetPublishedFileDetailsResult_t_118": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W64_ARRAY(char, 129, m_rgchTitle);\n    W64_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    W64_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    W64_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    uint8_t __pad_9492[4];",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    uint8_t __pad_9492[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageGetPublishedFileDetailsResult_t_119": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W64_ARRAY(char, 129, m_rgchTitle);\n    W64_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    W64_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    W64_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    W64_ARRAY(char, 256, m_rgchURL);\n    uint8_t __pad_9748[4];",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint8_t __pad_9748[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageGetPublishedFileDetailsResult_t_119x": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W64_ARRAY(char, 129, m_rgchTitle);\n    W64_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    W64_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    W64_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    W64_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_eFileType;",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_eFileType;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageGetPublishedFileDetailsResult_t_123": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W64_ARRAY(char, 129, m_rgchTitle);\n    W64_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    W64_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    W64_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    W64_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_eFileType;",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_eFileType;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageGetPublishedFileDetailsResult_t_126": {
-   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W64_ARRAY(char, 129, m_rgchTitle);\n    W64_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    W64_ARRAY(char, 1025, m_rgchTags);\n    int8_t m_bTagsTruncated;\n    W64_ARRAY(char, 260, m_pchFileName);\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    W64_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_eFileType;\n    int8_t m_bAcceptedForUse;\n    uint8_t __pad_9753[7];",
+   "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    char m_rgchTags[1025];\n    int8_t m_bTagsTruncated;\n    char m_pchFileName[260];\n    uint8_t __pad_9483[1];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_eFileType;\n    int8_t m_bAcceptedForUse;\n    uint8_t __pad_9753[7];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageGetPublishedItemVoteDetailsResult_t_119": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_unPublishedFileId;\n    int32_t m_nVotesFor;\n    int32_t m_nVotesAgainst;\n    int32_t m_nReports;\n    float m_fScore;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_unPublishedFileId",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nVotesFor",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nVotesAgainst",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nReports",
+     0
+    ],
+    [
+     "float",
+     "m_fScore",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageGetPublishedItemVoteDetailsResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_unPublishedFileId;\n    int32_t m_nVotesFor;\n    int32_t m_nVotesAgainst;\n    int32_t m_nReports;\n    float m_fScore;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_unPublishedFileId",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nVotesFor",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nVotesAgainst",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nReports",
+     0
+    ],
+    [
+     "float",
+     "m_fScore",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStoragePublishFileResult_t_116x": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStoragePublishFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStoragePublishFileResult_t_125": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    int8_t m_bUserNeedsToAcceptWorkshopLegalAgreement;\n    uint8_t __pad_17[7];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserNeedsToAcceptWorkshopLegalAgreement",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStoragePublishedFileUpdated_t": {
    "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;\n    uint8_t __pad_12[4];\n    uint64_t m_ulUnused;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulUnused",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageSetUserPublishedFileActionResult_t_119": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eAction;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eAction",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageSetUserPublishedFileActionResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eAction;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eAction",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageSubscribePublishedFileResult_t_116x": {
    "body": "    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w64_RemoteStorageSubscribePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageUnsubscribePublishedFileResult_t_116x": {
    "body": "    uint32_t m_eResult;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ]
+   ],
    "pack": 4
   },
   "w64_RemoteStorageUnsubscribePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageUpdatePublishedFileRequest_t": {
    "body": "    uint64_t m_unPublishedFileId;\n    const char *m_pchFile;\n    const char *m_pchPreviewFile;\n    const char *m_pchTitle;\n    const char *m_pchDescription;\n    uint32_t m_eVisibility;\n    uint8_t __pad_44[4];\n    w64_SteamParamStringArray_t *m_pTags;\n    int8_t m_bUpdateFile;\n    int8_t m_bUpdatePreviewFile;\n    int8_t m_bUpdateTitle;\n    int8_t m_bUpdateDescription;\n    int8_t m_bUpdateVisibility;\n    int8_t m_bUpdateTags;\n    uint8_t __pad_62[2];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_unPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUpdateFile",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUpdatePreviewFile",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUpdateTitle",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUpdateDescription",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUpdateVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUpdateTags",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageUpdatePublishedFileResult_t_116x": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageUpdatePublishedFileResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageUpdatePublishedFileResult_t_125": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    int8_t m_bUserNeedsToAcceptWorkshopLegalAgreement;\n    uint8_t __pad_17[7];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUserNeedsToAcceptWorkshopLegalAgreement",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageUpdateUserPublishedItemVoteResult_t_119": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageUpdateUserPublishedItemVoteResult_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageUserVoteDetails_t_119": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eVote;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVote",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoteStorageUserVoteDetails_t_123": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_eVote;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVote",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoveAppDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint32_t m_nAppID;\n    uint8_t __pad_20[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nAppID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RemoveUGCDependencyResult_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_nPublishedFileId;\n    uint64_t m_nChildPublishedFileId;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_nChildPublishedFileId",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RequestPlayersForGameFinalResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ullSearchID;\n    uint64_t m_ullUniqueGameID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullSearchID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullUniqueGameID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RequestPlayersForGameProgressCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ullSearchID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullSearchID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_RequestPlayersForGameResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t m_ullSearchID;\n    CSteamID m_SteamIDPlayerFound;\n    CSteamID m_SteamIDLobby;\n    uint32_t m_ePlayerAcceptState;\n    int32_t m_nPlayerIndex;\n    int32_t m_nTotalPlayersFound;\n    int32_t m_nTotalPlayersAcceptedGame;\n    int32_t m_nSuggestedTeamIndex;\n    uint8_t __pad_52[4];\n    uint64_t m_ullUniqueGameID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullSearchID",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_SteamIDPlayerFound",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_SteamIDLobby",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_ePlayerAcceptState",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPlayerIndex",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalPlayersFound",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nTotalPlayersAcceptedGame",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nSuggestedTeamIndex",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ullUniqueGameID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamInputConfigurationLoaded_t": {
    "body": "    uint32_t m_unAppID;\n    uint8_t __pad_4[4];\n    uint64_t m_ulDeviceHandle;\n    CSteamID m_ulMappingCreator;\n    uint32_t m_unMajorRevision;\n    uint32_t m_unMinorRevision;\n    int8_t m_bUsesSteamInputAPI;\n    int8_t m_bUsesGamepadAPI;\n    uint8_t __pad_34[6];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulDeviceHandle",
+     0
+    ],
+    [
+     "CSteamID",
+     "m_ulMappingCreator",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unMajorRevision",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unMinorRevision",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUsesSteamInputAPI",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bUsesGamepadAPI",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamInputGamepadSlotChange_t": {
    "body": "    uint32_t m_unAppID;\n    uint8_t __pad_4[4];\n    uint64_t m_ulDeviceHandle;\n    uint32_t m_eDeviceType;\n    int32_t m_nOldGamepadSlot;\n    int32_t m_nNewGamepadSlot;\n    uint8_t __pad_28[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_unAppID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulDeviceHandle",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eDeviceType",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nOldGamepadSlot",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nNewGamepadSlot",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamInventoryStartPurchaseResult_t": {
    "body": "    uint32_t m_result;\n    uint8_t __pad_4[4];\n    uint64_t m_ulOrderID;\n    uint64_t m_ulTransID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_result",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulOrderID",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulTransID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamNetConnectionStatusChangedCallback_t_144": {
    "body": "    uint32_t m_hConn;\n    uint8_t __pad_4[4];\n    SteamNetConnectionInfo_t_144 m_info;\n    uint32_t m_eOldState;\n    uint8_t __pad_708[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hConn",
+     0
+    ],
+    [
+     "SteamNetConnectionInfo_t_144",
+     "m_info",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eOldState",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamNetConnectionStatusChangedCallback_t_151": {
    "body": "    uint32_t m_hConn;\n    uint8_t __pad_4[4];\n    SteamNetConnectionInfo_t_151 m_info;\n    uint32_t m_eOldState;\n    uint8_t __pad_580[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hConn",
+     0
+    ],
+    [
+     "SteamNetConnectionInfo_t_151",
+     "m_info",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eOldState",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamNetConnectionStatusChangedCallback_t_153a": {
    "body": "    uint32_t m_hConn;\n    uint8_t __pad_4[4];\n    SteamNetConnectionInfo_t_153a m_info;\n    uint32_t m_eOldState;\n    uint8_t __pad_708[4];",
+   "fields": [
+    [
+     "uint32_t",
+     "m_hConn",
+     0
+    ],
+    [
+     "SteamNetConnectionInfo_t_153a",
+     "m_info",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eOldState",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamNetworkingMessage_t_144": {
    "body": "    void *m_pData;\n    uint32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_144 m_sender;\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*W_CDECL m_pfnFreeData)(w64_SteamNetworkingMessage_t_144 *);\n    void (*W_CDECL m_pfnRelease)(w64_SteamNetworkingMessage_t_144 *);\n    int32_t m_nChannel;\n    int32_t m___nPadDummy;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_144",
+     "m_sender",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m___nPadDummy",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamNetworkingMessage_t_147": {
    "body": "    void *m_pData;\n    int32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_144 m_identityPeer;\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*W_CDECL m_pfnFreeData)(w64_SteamNetworkingMessage_t_147 *);\n    void (*W_CDECL m_pfnRelease)(w64_SteamNetworkingMessage_t_147 *);\n    int32_t m_nChannel;\n    int32_t m_nFlags;\n    int64_t m_nUserData;",
+   "fields": [
+    [
+     "int32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_144",
+     "m_identityPeer",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nFlags",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamNetworkingMessage_t_151": {
    "body": "    void *m_pData;\n    int32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_151 m_identityPeer;\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*W_CDECL m_pfnFreeData)(w64_SteamNetworkingMessage_t_151 *);\n    void (*W_CDECL m_pfnRelease)(w64_SteamNetworkingMessage_t_151 *);\n    int32_t m_nChannel;\n    int32_t m_nFlags;\n    int64_t m_nUserData;",
+   "fields": [
+    [
+     "int32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_151",
+     "m_identityPeer",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nFlags",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamNetworkingMessage_t_153a": {
    "body": "    void *m_pData;\n    int32_t m_cbSize;\n    uint32_t m_conn;\n    SteamNetworkingIdentity_144 m_identityPeer;\n    int64_t m_nConnUserData;\n    int64_t m_usecTimeReceived;\n    int64_t m_nMessageNumber;\n    void (*W_CDECL m_pfnFreeData)(w64_SteamNetworkingMessage_t_153a *);\n    void (*W_CDECL m_pfnRelease)(w64_SteamNetworkingMessage_t_153a *);\n    int32_t m_nChannel;\n    int32_t m_nFlags;\n    int64_t m_nUserData;\n    uint16_t m_idxLane;\n    uint16_t _pad1__;\n    uint8_t __pad_212[4];",
+   "fields": [
+    [
+     "int32_t",
+     "m_cbSize",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_conn",
+     0
+    ],
+    [
+     "SteamNetworkingIdentity_144",
+     "m_identityPeer",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nConnUserData",
+     0
+    ],
+    [
+     "int64_t",
+     "m_usecTimeReceived",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nMessageNumber",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nChannel",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nFlags",
+     0
+    ],
+    [
+     "int64_t",
+     "m_nUserData",
+     0
+    ],
+    [
+     "uint16_t",
+     "m_idxLane",
+     0
+    ],
+    [
+     "uint16_t",
+     "_pad1__",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamParamStringArray_t": {
    "body": "    const char **m_ppStrings;\n    int32_t m_nNumStrings;\n    uint8_t __pad_12[4];",
+   "fields": [
+    [
+     "int32_t",
+     "m_nNumStrings",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamPartyBeaconLocation_t": {
    "body": "    uint32_t m_eType;\n    uint8_t __pad_4[4];\n    uint64_t m_ulLocationID;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eType",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulLocationID",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamUGCDetails_t_126": {
-   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W64_ARRAY(char, 129, m_rgchTitle);\n    W64_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    W64_ARRAY(char, 1025, m_rgchTags);\n    uint8_t __pad_9212[4];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    W64_ARRAY(char, 260, m_pchFileName);\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    W64_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;",
+   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    char m_rgchTags[1025];\n    uint8_t __pad_9212[4];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    char m_pchFileName[260];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeAddedToUserList",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_unVotesUp",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVotesDown",
+     0
+    ],
+    [
+     "float",
+     "m_flScore",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamUGCDetails_t_128x": {
-   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W64_ARRAY(char, 129, m_rgchTitle);\n    W64_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    W64_ARRAY(char, 1025, m_rgchTags);\n    uint8_t __pad_9212[4];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    W64_ARRAY(char, 260, m_pchFileName);\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    W64_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;\n    uint8_t __pad_9772[4];",
+   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    char m_rgchTags[1025];\n    uint8_t __pad_9212[4];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    char m_pchFileName[260];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;\n    uint8_t __pad_9772[4];",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeAddedToUserList",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_unVotesUp",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVotesDown",
+     0
+    ],
+    [
+     "float",
+     "m_flScore",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unNumChildren",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamUGCDetails_t_160": {
-   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    W64_ARRAY(char, 129, m_rgchTitle);\n    W64_ARRAY(char, 8000, m_rgchDescription);\n    uint8_t __pad_8153[7];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    W64_ARRAY(char, 1025, m_rgchTags);\n    uint8_t __pad_9212[4];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    W64_ARRAY(char, 260, m_pchFileName);\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    W64_ARRAY(char, 256, m_rgchURL);\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;\n    uint8_t __pad_9772[4];\n    uint64_t m_ulTotalFilesSize;",
+   "body": "    uint64_t m_nPublishedFileId;\n    uint32_t m_eResult;\n    uint32_t m_eFileType;\n    uint32_t m_nCreatorAppID;\n    uint32_t m_nConsumerAppID;\n    char m_rgchTitle[129];\n    char m_rgchDescription[8000];\n    uint8_t __pad_8153[7];\n    uint64_t m_ulSteamIDOwner;\n    uint32_t m_rtimeCreated;\n    uint32_t m_rtimeUpdated;\n    uint32_t m_rtimeAddedToUserList;\n    uint32_t m_eVisibility;\n    int8_t m_bBanned;\n    int8_t m_bAcceptedForUse;\n    int8_t m_bTagsTruncated;\n    char m_rgchTags[1025];\n    uint8_t __pad_9212[4];\n    uint64_t m_hFile;\n    uint64_t m_hPreviewFile;\n    char m_pchFileName[260];\n    int32_t m_nFileSize;\n    int32_t m_nPreviewFileSize;\n    char m_rgchURL[256];\n    uint32_t m_unVotesUp;\n    uint32_t m_unVotesDown;\n    float m_flScore;\n    uint32_t m_unNumChildren;\n    uint8_t __pad_9772[4];\n    uint64_t m_ulTotalFilesSize;",
+   "fields": [
+    [
+     "uint64_t",
+     "m_nPublishedFileId",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eFileType",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nCreatorAppID",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_nConsumerAppID",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTitle",
+     129
+    ],
+    [
+     "char",
+     "m_rgchDescription",
+     8000
+    ],
+    [
+     "uint64_t",
+     "m_ulSteamIDOwner",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeCreated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeUpdated",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_rtimeAddedToUserList",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_eVisibility",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bBanned",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bAcceptedForUse",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bTagsTruncated",
+     0
+    ],
+    [
+     "char",
+     "m_rgchTags",
+     1025
+    ],
+    [
+     "uint64_t",
+     "m_hFile",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_hPreviewFile",
+     0
+    ],
+    [
+     "char",
+     "m_pchFileName",
+     260
+    ],
+    [
+     "int32_t",
+     "m_nFileSize",
+     0
+    ],
+    [
+     "int32_t",
+     "m_nPreviewFileSize",
+     0
+    ],
+    [
+     "char",
+     "m_rgchURL",
+     256
+    ],
+    [
+     "uint32_t",
+     "m_unVotesUp",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unVotesDown",
+     0
+    ],
+    [
+     "float",
+     "m_flScore",
+     0
+    ],
+    [
+     "uint32_t",
+     "m_unNumChildren",
+     0
+    ],
+    [
+     "uint64_t",
+     "m_ulTotalFilesSize",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamUGCRequestUGCDetailsResult_t_126": {
    "body": "    w64_SteamUGCDetails_t_126 m_details;",
+   "fields": [
+    [
+     "w64_SteamUGCDetails_t_126",
+     "m_details",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamUGCRequestUGCDetailsResult_t_128x": {
    "body": "    w64_SteamUGCDetails_t_128x m_details;\n    int8_t m_bCachedData;\n    uint8_t __pad_9777[7];",
+   "fields": [
+    [
+     "w64_SteamUGCDetails_t_128x",
+     "m_details",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamUGCRequestUGCDetailsResult_t_129": {
    "body": "    w64_SteamUGCDetails_t_126 m_details;\n    int8_t m_bCachedData;\n    uint8_t __pad_9769[7];",
+   "fields": [
+    [
+     "w64_SteamUGCDetails_t_126",
+     "m_details",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SteamUGCRequestUGCDetailsResult_t_160": {
    "body": "    w64_SteamUGCDetails_t_160 m_details;\n    int8_t m_bCachedData;\n    uint8_t __pad_9785[7];",
+   "fields": [
+    [
+     "w64_SteamUGCDetails_t_160",
+     "m_details",
+     0
+    ],
+    [
+     "int8_t",
+     "m_bCachedData",
+     0
+    ]
+   ],
    "pack": 8
   },
   "w64_SubmitPlayerResultResultCallback_t": {
    "body": "    uint32_t m_eResult;\n    uint8_t __pad_4[4];\n    uint64_t ullUniqueGameID;\n    CSteamID steamIDPlayer;",
+   "fields": [
+    [
+     "uint32_t",
+     "m_eResult",
+     0
+    ],
+    [
+     "uint64_t",
+     "ullUniqueGameID",
+     0
+    ],
+    [
+     "CSteamID",
+     "steamIDPlayer",
+     0
+    ]
+   ],
    "pack": 8
   }
  }


### PR DESCRIPTION
Follow-up to #82. Attacks both classes you named: **residue 44 → 37**, and the divergent-layout class closes entirely.

## `void*` returns: 4 → 2

Over-stated last time. Of the four:

- **`DEPRECATED_GetISteamUnifiedMessages`** is an ordinary interface getter Valve retired in place. `wire_getters` already serves every sibling and missed it only because its prefix test reads `GetISteam` and the name begins `DEPRECATED_GetISteam`. One-line fix.
- **`GetServerDetails`** returns a pointer to a struct Proton states both sides agree on. On x86_64 that's the same move a `const char *` return already makes — one address space, dereferenced in place. Generated x86_64-only.
- **`GetIVAC`** and **`CreateFakeUDPPort`** genuinely resist: both return interface pointers we can't hand a title without presenting a PE vtable for them.

## Divergent layouts: 6 → 0

The conversion is entirely mechanical — Proton states both layouts, and the field **names and order are identical** between them; only the explicit `__pad_N[]` members fall differently. What isn't derivable is two facts per parameter, and both tempting heuristics fail:

- **Direction is not `const`-ness.** `ISteamParties::CreateBeacon` takes a non-const pointer that is an **input** (the location to open a beacon at), while the other five non-const cases are outputs. A `const`-keyed rule would have handed `CreateBeacon`'s caller back its own uninitialised buffer.
- **Extent is not in the type.** `GetAvailableBeaconLocations` fills an **array** whose element count is the next parameter.

So `overrides.json` grows a `marshal` section naming, per (interface, method, argument), the direction and the count. Without it such a parameter is still refused — the generator never guesses either fact. `param` records the name the argument must have, **checked against every version at generation time**, so a version that renames or reorders parameters fails the build instead of marshalling the wrong one.

## The new gate, and it has teeth

`check_convert.py` proves the copy is complete **without reading the converter**. It takes Proton's field list from `structs.json`, fills the Windows struct with one byte pattern and the destination with another, runs `w2u` then `u2w`, and compares every declared field. A field the converter never copies keeps the second pattern and is caught — the check and the generator derive from the same source by different routes, so they'd have to be wrong in the same way.

Verified by dropping a single field from a generated converter:

```
  LeaderboardEntry_t_123.m_nScore NOT COPIED
layout converters DROP fields — see above. A dropped field leaves the caller
reading whatever was in its buffer before the call, which is a plausible value
and not an error.
```

Clean run: `converters: 5 structs, 85 fields round-trip w64 -> u64 -> w64 intact`.

| | before | after |
| --- | ---: | ---: |
| methods refused (real residue) | 44 | **37** |
| vtable slots wired | 5,191 | **5,218** |
| shapes emitted | 1,143 | **1,152** (31 x86_64-only) |

## What's left

25 with no readable signature, 10 function-pointer parameters, 2 interface-pointer returns. None is a generator change — each needs a mechanism the seam doesn't have, or the logic Proton hand-wrote those wrappers to carry.

## Not verified at runtime

**No title in hand calls a converted method** — they're party beacons, leaderboard entries and workshop details. These rest on the build gates. The achievement path and both `GetStat` overloads still pass unchanged through the harness.

Also filed #83 for `ISteamNetworkingFakeUDPPort`, the interface the original #47–#77 sweep missed.

ADR 0009.