### PR TITLE
Merge into DYLD_INSERT_LIBRARIES instead of clobbering it

### DIFF
--- a/src/installer/install.sh
+++ b/src/installer/install.sh
@@ -206,7 +206,28 @@ cat <<'LAUNCHER'
 # "off". Then hand off to Valve's own binary, unmodified.
 : "${HOME:?launcher: HOME is unset — cannot locate the payload or Steam}"
 LAUNCHER
-printf 'export DYLD_INSERT_LIBRARIES="$HOME/%s"\n'          "$SHIM_PATH_ENABLER_REL"
+printf 'shim_enabler="$HOME/%s"\n'                          "$SHIM_PATH_ENABLER_REL"
+cat <<'LAUNCHER'
+# DYLD_INSERT_LIBRARIES is a ':'-separated list and we are one entry in it, not
+# the owner of it (#85): prepend ours, keep whatever was already there, and add
+# ourselves only once. Membership is tested on RESOLVED paths — the same dylib
+# spelled relative or reached through a symlink is still the same dylib, and
+# comparing literals is how the list grows without bound across nested launches.
+# Measured caveat: an INHERITED value never reaches here, because /bin/sh drops
+# DYLD_* on the way in. The merge is still the behaviour #42's launcher — a
+# Mach-O, which does inherit it — has to carry over.
+shim_ours=$(/bin/realpath -q "$shim_enabler" || printf '%s' "$shim_enabler")
+shim_rest="${DYLD_INSERT_LIBRARIES-}"
+while [ -n "$shim_rest" ]; do
+    shim_entry="${shim_rest%%:*}"
+    case "$shim_rest" in *:*) shim_rest="${shim_rest#*:}" ;; *) shim_rest="" ;; esac
+    [ "$(/bin/realpath -q "$shim_entry" || printf '%s' "$shim_entry")" = "$shim_ours" ] || continue
+    shim_ours=""   # already listed: leave the value exactly as it was found
+    break
+done
+[ -z "$shim_ours" ] || DYLD_INSERT_LIBRARIES="$shim_enabler${DYLD_INSERT_LIBRARIES:+:$DYLD_INSERT_LIBRARIES}"
+export DYLD_INSERT_LIBRARIES
+LAUNCHER
 printf 'export STEAM_EXTRA_COMPAT_TOOLS_PATHS="$HOME/%s"\n' "$SHIM_PATH_COMPAT_TOOLS_REL"
 printf 'export %s\n' "$SHIM_ENV_OVERLAY"
 printf 'exec "$HOME/%s" "$@"\n'                             "$SHIM_PATH_STEAM_OSX_REL"


### PR DESCRIPTION
Closes #85.

The generated launcher assigned `DYLD_INSERT_LIBRARIES` flat. Now it prepends ours and keeps whatever was there, adding ourselves only once — membership decided on `realpath`'d entries, so a relative or symlinked spelling of our own dylib does not get appended again on every nested launch. Stays inside the quoted heredoc; the only interpolated value is the manifest path, as before.

Behaviour, all exercised against the generated launcher body (12 cases: unset / empty / one other / two others / ours literal / ours+other / other+ours / ours via symlink / ours relative / unresolvable entry kept / trailing colon preserved / relaunch stable):

- unset or empty → ours alone
- already present, however spelled → value left byte-for-byte as found
- otherwise → `ours:existing`

**One finding that bounds the fix.** An *inherited* `DYLD_INSERT_LIBRARIES` never reaches a `#!/bin/sh` launcher at all — dyld does not honour an insertion into `/bin/sh` (a platform binary), and the shell does not keep the variable either:

```
$ DYLD_INSERT_LIBRARIES=/tmp/ctor.dylib /bin/sh -c 'echo "[${DYLD_INSERT_LIBRARIES-UNSET}]"'
[UNSET]            # and the constructor never runs
$ DYLD_INSERT_LIBRARIES=/tmp/ctor.dylib ./showenv
DYLD_INSERT_LIBRARIES=/tmp/ctor.dylib   # ctor loaded
```

So the clobber the issue describes was not observable through today's launcher: there was nothing to clobber. The merge ships anyway — it is the behaviour #42's SwiftUI launcher (a plain Mach-O, which *does* inherit the variable) has to carry over, and the no-duplicate half is real for any value the launcher's own shell holds. #85's first acceptance criterion — "launched with a pre-existing value, execs `steam_osx` with both entries present" — cannot be met by an `sh` launcher; it becomes a #42 acceptance test.

Verified: `install.sh` re-run clean, generated launcher passes `sh -n`, and the merge cases above run against the generated body. Not verified: a real Steam launch through the new launcher — Steam was already running on this machine, so that is still worth a quick manual pass.
