### PR TITLE
fix: a first install on a clean machine could not work, and said the wrong thing about why

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ This app is an attempt to brings the steamdeck's [Steam Play](https://store.stea
 ```sh
 brew tap Superd22/macos-steam
 brew install macos-steam-shim
+macos-steam-shim              # the deploy step — brew cannot do this one for you
 ```
+
+The third line is not optional and not a repair step. `brew install` builds the
+payload; putting it in your home directory is a separate command because a
+formula's install steps are sandboxed away from `$HOME`, which is the only place
+this payload can live.
 
 ### From a clone
 
@@ -26,7 +32,10 @@ brew install macos-steam-shim
 - Apple Silicon Mac, macOS 14+ (developed on macOS 26, M3 Pro).
 - **CrossOver** installed at `~/Applications/CrossOver.app` (25.1.1 and 26.2 both exercised).
   CrossOver is required. The launch goes through its front door, so its D3DMetal/GPTK wiring comes along.
-- The **native macOS Steam client**, installed, and signed in **online**.
+- The **native macOS Steam client** — installed, **opened at least once**, and signed
+  in **online**. Steam.app is a bootstrapper; the client this project execs is the one
+  Steam unpacks under `~/Library/Application Support/Steam/` on its first successful
+  run, so a Steam that has been downloaded but never launched is not yet enough.
 - Xcode command line tools (`xcode-select --install`) — Homebrew requires them anyway.
   The cross-compiler comes from the formula, so there is nothing else to install by hand.
   The contributor path, and the one to use if you want the sources in front of you:

--- a/src/installer/deploy.sh
+++ b/src/installer/deploy.sh
@@ -193,15 +193,36 @@ esac
 [ -n "$PAYLOAD" ] || die "no payload — pass --payload DIR (build it with src/installer/build.sh)"
 [ -f "$PAYLOAD/VERSION" ] || die "$PAYLOAD is not a payload — no VERSION file"
 VERSION="$(tr -d ' \n' < "$PAYLOAD/VERSION")"
+# What we exec is not what Valve's installer puts on disk. Steam.app ships a
+# bootstrapper; the bundle we exec is the one it unpacks under Application
+# Support on its FIRST successful run. So a fresh machine that has installed
+# Steam and never opened it fails this check with Steam sitting right there in
+# /Applications — and "native Steam not found" sends that user off to download
+# what they already have. The two states are one stat call apart and their
+# remedies have nothing in common, so they get two messages.
+steam_app_installed() {
+    [ -d "/$SHIM_PATH_STEAM_APP_REL" ] || [ -d "$HOME/$SHIM_PATH_STEAM_APP_REL" ]
+}
 if [ ! -x "$STEAM_OSX" ]; then
+    if steam_app_installed; then
+        why="Steam is installed but has never finished its first run, so the
+      bundle we exec does not exist yet. Open Steam.app, sign in ONLINE, let
+      it update, then quit it and run this again."
+    else
+        why="The native macOS Steam client is not installed.
+      Get it from https://store.steampowered.com/about/ and sign in ONLINE."
+    fi
     # A real deploy refuses: writing a launcher that execs a steam_osx which is
     # not there is not a partial success, it is a broken install that looks
     # finished. A DRY RUN is the opposite case — it is a report, and "you have
     # no native Steam" is precisely the thing a report should tell you, so it
     # says so and goes on to print the rest of the plan. That is also what makes
     # the deploy contract checkable on a machine that has no Steam, like CI.
-    [ "$DRYRUN" = 1 ] || die "native Steam not found at $STEAM_OSX"
+    [ "$DRYRUN" = 1 ] || die "native Steam not found at
+      $STEAM_OSX
+      $why"
     log "native Steam NOT found at $STEAM_OSX — a real deploy would stop here"
+    log "$why"
 fi
 
 # Overlay (#21, ADR 0006). ON by default. The value is baked into the launcher

--- a/src/installer/packaging/macos-steam-shim.rb.in
+++ b/src/installer/packaging/macos-steam-shim.rb.in
@@ -70,31 +70,45 @@ class MacosSteamShim < Formula
     SH
   end
 
-  # The deploy half, run for the user so the terminal appears exactly once.
+  # There is no post_install, and there cannot be one.
   #
-  # Homebrew's sandbox governs what this may write, and the payload's home is
-  # under $HOME, not the prefix — so this is allowed to fail without failing
-  # the install. The formula's job was to BUILD; if the sandbox refuses the
-  # write, the caveats below name the one command that finishes the job, and
-  # the user is one paste from done rather than staring at a failed install.
-  def post_install
-    system libexec/"deploy.sh"
-  rescue
-    opoo "Could not deploy automatically — run `macos-steam-shim` to finish."
-  end
+  # This formula used to run deploy.sh here so the user never had to type a
+  # command. It never once worked, on any machine — and it failed in a way that
+  # read like bad luck rather than a bug, because it warned and moved on:
+  #
+  #   [deploy] native Steam not found at
+  #            /private/tmp/macos-steam-shim-postinstall-.../Library/...
+  #   Warning: Could not deploy automatically — run `macos-steam-shim` to finish.
+  #
+  # Look at the path. Homebrew gives post_install an ISOLATED $HOME — a fresh
+  # `Dir.mktmpdir("#{name}-postinstall-")` (Formula#run_post_install) — and every
+  # path deploy.sh builds hangs off $HOME. So it looked for Steam inside a temp
+  # dir made seconds earlier, and would have deployed the payload there too.
+  # Then the sandbox around the whole step allows writes to the cellar, the
+  # prefix, the logs and Xcode, and nowhere else: even handed the real $HOME it
+  # would be denied. Both facts are deliberate on Homebrew's part. A formula does
+  # not install into a user's home directory, and this payload lives nowhere else.
+  #
+  # So the deploy is the user's step, and the caveats say so as a step rather
+  # than as a fallback for a failure that was never conditional.
 
   def caveats
     <<~EOS
-      Deployed:
+      brew built it; one command installs it. Run this now:
+        macos-steam-shim
+
+      That deploys:
         the payload  ~/@PAYLOAD_REL@/
         the launcher ~/@LAUNCHER_REL@
 
-      If the install could not write those, run this once to finish:
-        macos-steam-shim
+      (brew cannot do it for you: a formula's install steps are sandboxed away
+      from your home directory, which is where all of the above has to live.)
 
       You also need, and this formula cannot install them for you:
         - CrossOver at ~/Applications/CrossOver.app
-        - the native macOS Steam client, installed and signed in ONLINE
+        - the native macOS Steam client, OPENED at least once and signed in
+          ONLINE. A Steam that has been installed but never launched has not
+          unpacked the client yet, and the deploy above will tell you so.
 
       Quit Steam, then open "Steam (macOS Play)" instead of Steam.app from now
       on. Windows-only titles gain a Play button; the first launch of the app

--- a/src/launcher/Preflight.swift
+++ b/src/launcher/Preflight.swift
@@ -19,6 +19,11 @@ enum Verdict: Equatable {
 
 enum Remedy: Equatable {
     case openURL(URL)
+    /// Launch a bundle already on disk, by path. Distinct from `openURL` on a
+    /// file URL, which would do the same thing while reading as "go and get
+    /// this": the only check that offers it is the one whose whole point is
+    /// that the app is already there.
+    case openApp(String)
     case createBottle
     case reinstall
     case none
@@ -106,6 +111,25 @@ enum Preflight {
     // explains far better than we can.
     static func steam() -> Check {
         guard FileManager.default.isExecutableFile(atPath: Launch.steamOsx) else {
+            // Two states, not one. Valve's installer puts Steam.app down; the
+            // bundle we exec is the one Steam's bootstrapper unpacks under
+            // Application Support on its first successful run. So a machine
+            // that has installed Steam and never opened it lands here with
+            // Steam.app sitting right there — and "Install Steam first" over a
+            // Get Steam button sends that user to re-download what they have,
+            // which will not fix it however many times they do it.
+            let fm = FileManager.default
+            if fm.fileExists(atPath: "/" + ShimPath.steamAppRel)
+                || fm.fileExists(atPath: ShimPath.inHome(ShimPath.steamAppRel)) {
+                return Check(id: "steam", title: "Steam has never been opened",
+                             verdict: .blocked,
+                             detail: "Steam is installed but has not finished its first run, "
+                                   + "so the client this app starts does not exist yet. Open "
+                                   + "Steam, sign in while online, let it update, then quit it "
+                                   + "and come back here.",
+                             remedy: .openApp("/" + ShimPath.steamAppRel),
+                             remedyTitle: "Open Steam")
+            }
             return Check(id: "steam", title: "Steam installed",
                          verdict: .blocked,
                          detail: "This app starts your normal Steam. Install Steam first.",

--- a/src/launcher/UI.swift
+++ b/src/launcher/UI.swift
@@ -303,6 +303,10 @@ struct ChecklistView: View {
     private func remedy(for check: Check) -> some View {
         switch check.remedy {
         case .openURL(let url): Link(check.remedyTitle, destination: url)
+        case .openApp(let path):
+            Button(check.remedyTitle) {
+                NSWorkspace.shared.open(URL(fileURLWithPath: path))
+            }
         case .createBottle: Button(check.remedyTitle) { model.createBottle() }.disabled(model.busy != nil)
         case .reinstall: Button(check.remedyTitle) { Help.showReinstall() }
         case .none: EmptyView()

--- a/src/layout/layout.json
+++ b/src/layout/layout.json
@@ -46,6 +46,7 @@
     { "name": "STEAM_MACOS_REL", "value": "Library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS", "what": "native Steam's MacOS dir, relative to $HOME", "guard": true },
     { "name": "CX_BOTTLES_REL","value": "Library/Application Support/CrossOver/Bottles", "what": "CrossOver's bottle root, relative to $HOME", "guard": true },
     { "name": "CX_APP_REL",    "value": "Applications/CrossOver.app", "what": "CrossOver.app, relative to $HOME" },
+    { "name": "STEAM_APP_REL", "value": "Applications/Steam.app", "what": "Valve's installer-placed bundle, relative to $HOME or to /. NOT where we exec Steam from — STEAM_MACOS_REL is. This one exists only to tell 'Steam is not installed' apart from 'Steam is installed and has never been run', which are one stat call and two entirely different remedies" },
     { "name": "LAUNCHER_REL",  "value": "Applications/Steam (macOS Play).app", "what": "our launcher .app, relative to $HOME", "guard": true },
     { "name": "LAUNCHER_BIN",  "value": "launcher",            "what": "the .app's CFBundleExecutable — the name deploy.sh writes and the bundle names back" },
     { "name": "SETTINGS_APP",  "value": "Steam Play Settings.app", "what": "nested helper app inside the launcher bundle: same binary, settings flag, so Spotlight finds the pane without the option-click trick" },


### PR DESCRIPTION
Two bugs found by installing the tap on a machine that had never built the repo. They are independent, but they compound: the first guarantees the install stops halfway, and the second makes the message you get at that point point away from the fix.

## 1. `post_install` never deployed anything, on any machine

The formula ran `deploy.sh` from `post_install` so the user would not have to type a command. It has never succeeded. It also never failed loudly — it `opoo`s and moves on, so the warning reads as bad luck on that machine rather than as an unconditional bug.

The install log gives it away:

```
[deploy] native Steam not found at
         /private/tmp/macos-steam-shim-postinstall-20260905-43020-ejpso2/Library/...
```

That is `$HOME`. `Formula#run_post_install` hands the step a fresh `Dir.mktmpdir("#{name}-postinstall-")` as `HOME`, and every path `deploy.sh` builds hangs off `$HOME` — so it looked for Steam in a directory created seconds earlier, and had it found one it would have deployed the payload there too.

Handing it the real home would not help: the sandbox around the step allows writes to the cellar, the prefix, the logs and Xcode, and nothing else. Both facts are deliberate on Homebrew's part — a formula does not write into a user's home directory, and this payload lives nowhere else.

So there is no fix that keeps the step. The deploy is the user's command; the caveats and the README now present it as step three of the install rather than as a fallback for a failure that was never conditional.

## 2. "Install Steam first", to a user with Steam installed

`Steam.app` is a bootstrapper. The client we exec is the bundle Steam unpacks under Application Support on its **first successful run** — so `STEAM_MACOS_REL` does not exist on a machine where Steam has been installed and never opened, which is every machine on the day it is set up, and was the machine in this report.

Both checks read that as "no Steam":

- `deploy.sh` said `native Steam not found at /Users/.../Steam.AppBundle/...` with Steam sitting in `/Applications`.
- the launcher's preflight said **"Install Steam first"** over a **Get Steam** button — advice that cannot work however many times it is followed, since re-downloading Steam does not run it.

The two states are one stat call apart and share no remedy, so they now get two messages. A `Steam.app` on disk means "open it once, sign in online, let it update"; the launcher's button opens the Steam already there rather than the download page. `STEAM_APP_REL` joins the manifest to hold the one path both halves probe — it is never exec'd, it exists only to separate the two states.

## Verification

On the reported machine, in both states:

```
$ HOME=<scratch> deploy.sh
[deploy] native Steam not found at
      <scratch>/Library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/steam_osx
      Steam is installed but has never finished its first run, so the
      bundle we exec does not exist yet. Open Steam.app, sign in ONLINE, let
      it update, then quit it and run this again.
```

and after opening Steam once, the same deploy succeeds unchanged (launcher, payload, 29-file receipt). `src/installer/build.sh` and `src/layout/build.sh` are clean — 30 guarded values, no drift — and the rendered formula parses under `ruby -c`.

## Note on shipping

Neither fix reaches a user until the next release: `deploy.sh` ships inside the payload tarball, and the tap holds the already-rendered 0.3.0 formula. Editing the tap alone would be undone by the next `push-to-tap.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)