### PR TITLE
feat(launcher): state the wildcard mapping so Windows titles are installable here

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -148,7 +148,17 @@ decisions (those live in `docs/adr/`). Update the moment a term is coined or sha
 
 - **Compat gate** — the single latched boolean (`m_bCompatEnabled`) in the macOS client that
   turns the whole Steam Play subsystem on. Off by default on macOS; crossable with a one-byte
-  patch. The subject of Level A.
+  patch. The subject of Level A. It answers *whether* compat runs, never *which tool* — that
+  is the **wildcard mapping**, and neither half is any use without the other.
+
+- **Wildcard mapping** — the standing answer to "which compat tool should a title use when
+  nobody has chosen one for it": Valve's own term, the mapping stored against appid `0`. Until
+  one exists a title has no tool *selected*, so the client answers "not available on this
+  platform" even with the gate open and our tool registered — registering a tool declares it
+  willing, it does not select it. On Linux the user writes it by ticking "Enable Steam Play for
+  all other titles"; that settings page is not drawn on macOS, so nothing ever writes it and we
+  state it ourselves (ADR 0015). Honoured only at priority ≥ 250; below that the client stores
+  the entry and never consults it.
 
 - **Bottle** — a CrossOver Wine prefix. A **clean bottle** is one with no Windows Steam
   installed, required so the shim is tested without the real `steamclient64.dll` winning the

--- a/docs/adr/0015-the-wildcard-mapping-is-stated-by-the-launcher-not-written-into-valves-config.md
+++ b/docs/adr/0015-the-wildcard-mapping-is-stated-by-the-launcher-not-written-into-valves-config.md
@@ -1,0 +1,108 @@
+# 15. The wildcard mapping is stated by the launcher, not written into Valve's config
+
+Date: 2026-09-05
+
+## Status
+
+Accepted
+
+Completes the **compat gate** ([research](../research/compat-vdf-platform-override.md)), which
+turns the subsystem on but never says which tool it should reach for. Resolves
+[#102](https://github.com/Superd22/macos-steam/issues/102).
+
+## Context
+
+A Windows-only title **already installed on another machine on the account** offered only
+_Stream from `<machine>`_ in the macOS library. No install option anywhere — not on the button,
+not in the machine picker. Every other Windows title installed and launched normally.
+
+The machine picker is built from `per_client_data` on the app overview, one row per machine.
+`CSteamUIAppController::FillInAppOverview` in `steamui.dylib` builds it, and the local row is
+pushed only when a predicate on the app answers true. That predicate is
+`is_available_on_current_platform` — the same value the row would have carried. A machine that
+cannot run the title is not listed as unable to run it; it is not listed at all.
+
+The value is the client's. `CUserAppManager::GetAppStateInfo` sets it through
+`GetSystemConfigurationForApp`, the **compat-aware** variant, so there is no third
+non-compat-aware call site — the hypothesis #102 opened with, and it was wrong. What that
+function needs is `BIsCompatibilityToolEnabled(appid)`, which asks whether a tool is
+**selected** for the title, not whether one is available. Nothing selects one for a title that
+has never been installed: Steam writes the selection as part of installing.
+
+Which is why the bug hid. With no other machine owning the title the machine list comes back
+empty, no picker is drawn, the ordinary install button appears — and pressing it is what
+creates the selection. A second machine makes the list non-empty, so the picker replaces that
+button, and the picker is built from a list we were never added to. The one affordance that
+would have made the selection is the one its absence removes.
+
+On Linux and on Deck the same code runs, but the selection exists up front: "Enable Steam Play
+for all other titles" writes it before any install. That settings page is drawn only when the
+platform is Linux — one string comparison in `steamui/library.js` — so on macOS nothing ever
+writes it.
+
+### What we measured
+
+Read live out of the running client, read-only, by locating the app objects in memory and
+reading the flags word. Titles reading "not available on this platform", library-wide:
+
+| configuration | unavailable |
+|---|---|
+| gate patched, no mapping | 455 / 750 |
+| gate patched + mapping | **57 / 750** |
+| mapping, gate **not** patched | 455 / 750 |
+
+The third row is the control, run twice — once with the mapping in `config.vdf` and once with
+it in the environment, byte-identical results both times. The client parses the mapping and
+logs it either way, then never applies it: `BIsCompatibilityToolEnabled` tests the gate byte
+before it reads anything. **Neither half works alone.**
+
+Confirmed at the UI level in the same session: with both halves live, a title installed only on
+the remote machine offers streaming *and* installing here.
+
+## Decision
+
+The launcher states the wildcard mapping in `steam_osx`'s environment:
+
+```
+STEAM_COMPAT_TOOL_MAPPINGS="0 <priority> <tool name>"
+```
+
+Beside `STEAM_EXTRA_COMPAT_TOOLS_PATHS`, which already delivers the tool the mapping names, and
+subject to the same rule: **Valve's spelling, our value.** The variable name stays in
+`Launch.swift` with the other borrowed names rather than moving into `layout.json`, because the
+manifest owns the contract this project defines and cannot own a spelling we do not control.
+The tool name is `ShimPath.toolName`, so the drift guard holds.
+
+Priority is stated as **250**, which is the client's threshold rather than a round number above
+it (`GetWildcardMapping`: `cmp w8, #0xfa`). Below it the entry is stored and never consulted,
+which is exactly the failure the shipped `compatibilitytool.vdf` already has: its own
+`app_mappings { "0" { priority "100" } }` is a *tool* declaring itself willing, it lands in a
+different map, and raising that number to 250 was measured to change nothing.
+
+### Rejected: writing `CompatToolMapping` into `config.vdf`
+
+Measured working, and rejected on delivery. It is Valve's file; the client rewrites it on exit,
+so the installer would have to refuse or defer while Steam is running; it outlives an uninstall
+unless we also learn to unwrite it; and it would be the first thing we ship that edits a file
+we do not own. The environment costs none of that and dies with the process.
+
+### Rejected: patching the predicate in `steamui.dylib`
+
+The four-instruction predicate is uniquely pattern-matchable and one `cset` away from always
+true. Rejected because it is downstream of the real decision and would also claim every
+*remote* machine can run every title. A second patched byte to say something false, when one
+environment variable says something true.
+
+## Consequences
+
+- The shipped stack still patches exactly **one** byte. This issue adds no new patch surface,
+  and nothing new to re-establish after a client update beyond what the gate already needs.
+- Our tool becomes the default for every title with no tool of its own — deliberately, and the
+  same thing the Linux toggle does. It is a library-wide behaviour change and belongs in the
+  receipt rather than happening quietly.
+- A title that already has a tool chosen keeps it: a wildcard mapping is the fallback, not an
+  override.
+- The mapping is only as live as the launcher. Steam started any other way is unmapped *and*
+  ungated, so the two failure modes stay together instead of drifting apart.
+- Addresses cited here are one `steamclient.dylib` / `steamui.dylib` build and expire with it.
+  The full trace, with instructions, lives in #102.

--- a/src/launcher/Launch.swift
+++ b/src/launcher/Launch.swift
@@ -3,15 +3,37 @@ import Foundation
 /// Handing off to Valve's own `steam_osx`, unmodified — the only thing this app
 /// does on the happy path (#42, ADR 0002 vehicle A).
 ///
-/// Two variables have to reach that process and nothing else does:
-/// `DYLD_INSERT_LIBRARIES` (the compat-gate injector) and
+/// Three variables have to reach that process and nothing else does:
+/// `DYLD_INSERT_LIBRARIES` (the compat-gate injector),
 /// `STEAM_EXTRA_COMPAT_TOOLS_PATHS` (our tool dir, outside every bundle so a
-/// client update cannot touch it). A third, the overlay switch, is stated so a
-/// compat tool started by Steam inherits an answer rather than a default.
+/// client update cannot touch it) and `STEAM_COMPAT_TOOL_MAPPINGS` (the
+/// wildcard mapping — the gate says compat runs, this says which tool it should
+/// reach for, and neither half is any use alone, ADR 0015). A fourth, the
+/// overlay switch, is stated so a compat tool started by Steam inherits an
+/// answer rather than a default.
 enum Launch {
     static var steamOsx: String { ShimPath.inHome(ShimPath.steamOsxRel) }
     static var enabler: String { ShimPath.inHome(ShimPath.enablerRel) }
     static var compatTools: String { ShimPath.inHome(ShimPath.compatToolsRel) }
+
+    /// The wildcard mapping (ADR 0015): one entry, `<appid> <priority> <tool>`,
+    /// naming the tool `compatTools` above delivers. It is the standing answer
+    /// to "which tool should a title use when nobody has chosen one for it",
+    /// and without it the client reports every Windows-only title as unavailable
+    /// on this platform — registering a tool declares it willing, it does not
+    /// select it.
+    static var toolMappings: String {
+        "\(wildcardAppID) \(wildcardPriority) \(ShimPath.toolName)"
+    }
+
+    /// Valve's "every app" sentinel in a compat tool mapping (`k_nAppIdAll`).
+    private static let wildcardAppID = 0
+
+    /// The client honours a wildcard mapping only at 250 or above; below that it
+    /// stores the entry and never consults it. Stated as the threshold itself
+    /// rather than a comfortable number above it, so the next reader can match
+    /// it against the client and see that it is a boundary and not a taste.
+    private static let wildcardPriority = 250
 
     /// The environment `steam_osx` should be started with, derived from the one
     /// we were started with. Pure, so the acceptance test for the merge below
@@ -23,6 +45,7 @@ enum Launch {
         var env = parent
         env[dyldInsertLibraries] = merged(insertions: parent[dyldInsertLibraries], ours: enabler)
         env[extraCompatToolsPaths] = compatTools
+        env[compatToolMappings] = toolMappings
         ShimPolicy.overlayExport(overlay, into: &env)
         return env
     }
@@ -87,6 +110,7 @@ enum Launch {
     // would claim ownership of a spelling we cannot change.
     static let dyldInsertLibraries = "DYLD_INSERT_LIBRARIES"
     static let extraCompatToolsPaths = "STEAM_EXTRA_COMPAT_TOOLS_PATHS"
+    static let compatToolMappings = "STEAM_COMPAT_TOOL_MAPPINGS"
 }
 
 /// `execve` wants a NULL-terminated array of C strings, and Swift will not keep

--- a/src/launcher/check_launch_env.sh
+++ b/src/launcher/check_launch_env.sh
@@ -10,7 +10,7 @@
 # The stated acceptance test is: launched with a pre-existing
 # DYLD_INSERT_LIBRARIES, the launcher hands steam_osx both entries with ours
 # first, and launching twice does not duplicate ours. That is asked here without
-# launching Steam at all, via --print-env, which prints exactly the three
+# launching Steam at all, via --print-env, which prints exactly the four
 # variables the exec would carry.
 set -eu
 cd "$(dirname "$0")"
@@ -73,6 +73,18 @@ case "$stored" in
     0)     expect "stored preference off: honoured over the environment" "$stated" "0" ;;
     *)     expect "stored preference on: honoured over the environment" "$stated" "1" ;;
 esac
+
+# The wildcard mapping is always STATED too, for the same reason the overlay is:
+# there is no macOS UI that could write one, so an absent variable is not "the
+# user chose nothing", it is every Windows-only title reporting itself
+# unavailable on this platform (ADR 0015). The priority is asserted as a number
+# and not just as "present" because it is a threshold in the client — at 249 the
+# entry is stored and silently never consulted, which looks exactly like working.
+echo "launcher: wildcard mapping is stated"
+mapping="$(env DYLD_INSERT_LIBRARIES= "./$BIN" $SHIM_PATH_PRINT_ENV_FLAG \
+           | sed -n 's/^STEAM_COMPAT_TOOL_MAPPINGS=//p')"
+expect "appid 0, at or above the client's threshold, naming our tool" \
+       "$mapping" "0 250 $SHIM_PATH_TOOL_NAME"
 
 [ "$fail" = 0 ] || exit 1
 echo "launcher: launch environment ok"

--- a/src/launcher/main.swift
+++ b/src/launcher/main.swift
@@ -47,7 +47,8 @@ if arguments.contains(ShimPath.diagnoseFlag) {
 }
 if arguments.contains(ShimPath.printEnvFlag) {
     let env = Launch.childEnvironment(overlay: Prefs.overlay)
-    for key in [Launch.dyldInsertLibraries, Launch.extraCompatToolsPaths, ShimPolicy.envOverlay] {
+    for key in [Launch.dyldInsertLibraries, Launch.extraCompatToolsPaths,
+                Launch.compatToolMappings, ShimPolicy.envOverlay] {
         print("\(key)=\(env[key] ?? "")")
     }
     exit(0)


### PR DESCRIPTION
Closes #102.

## The bug

A Windows-only title **already installed on another machine on the account** offered only _Stream from `<machine>`_ — no install option on the button, none in the machine picker. Every other Windows title installed and launched fine, which is what made it read as a streaming bug.

## What it actually is

The picker is built from `per_client_data`, and the local row is pushed only when the app answers `is_available_on_current_platform` — the same value the row would have carried. A machine that cannot run the title is not listed as unable to run it; it is not listed at all.

That value is the client's, set through `GetSystemConfigurationForApp`, the **compat-aware** variant. So there is no non-compat-aware call site to fix — the hypothesis the issue opened with, and it was wrong. What that path needs is `BIsCompatibilityToolEnabled`, which asks whether a tool is **selected** for the title, not whether one is available. Registering a tool declares it willing; nothing selects it. Steam writes the selection while installing, so a title never installed has none.

Which is why it hid: with no other machine owning the title the list comes back empty, no picker is drawn, the ordinary install button appears — and pressing it makes the selection. A second machine replaces that button with a picker built from a list this Mac was never added to, removing the one affordance that would have made the selection.

On Linux the selection exists up front, written by "Enable Steam Play for all other titles". That settings page is drawn only when the platform is Linux, so on macOS nothing ever writes it.

## The change

The launcher states it, beside `STEAM_EXTRA_COMPAT_TOOLS_PATHS` which already delivers the tool it names:

```
STEAM_COMPAT_TOOL_MAPPINGS="0 250 crossover-steam-shim"
```

- `CONTEXT.md` gains **wildcard mapping** as a term, and **compat gate** now says what it does *not* answer.
- ADR 0015 records the delivery decision and both rejected alternatives.
- `check_launch_env.sh` asserts the mapping is stated, with the priority as a number rather than just present.

## Measured

Read live out of the running client, read-only. Titles reporting themselves unavailable on this platform, library-wide:

| configuration | unavailable |
|---|---|
| gate patched, no mapping | 455 / 750 |
| gate patched + mapping | **57 / 750** |
| mapping, gate **not** patched | 455 / 750 |

Both failing titles from the report flipped, and it was confirmed in the UI in the same session: a title installed only on the remote machine now offers streaming *and* installing here. The final run above was the launcher built from this branch.

The third row is the control, run twice — once with the mapping in `config.vdf`, once in the environment, byte-identical both times. The client parses it either way and never applies it, because `BIsCompatibilityToolEnabled` tests the gate byte first. **Neither half works alone**, and the shipped stack still patches exactly one byte.

## Why 250

It is the client's threshold, not a round number above it. Below it the entry is stored and silently never consulted, which looks exactly like working. The shipped `compatibilitytool.vdf` already has that failure — its own `app_mappings` sit at 100 and land in a different map — and raising that number was measured to change nothing.

## Rejected

- **Writing `CompatToolMapping` into `config.vdf`.** Works, but it is Valve's file: the client rewrites it on exit, it outlives an uninstall unless we learn to unwrite it, and it would be the first thing we ship that edits a file we do not own.
- **A second patched byte in `steamui.dylib`.** The predicate is uniquely pattern-matchable and one instruction from always true, but it is downstream of the real decision and would also claim every *remote* machine can run every title.

## Notes for review

- Our tool becomes the default for every title that has not chosen one — deliberately, the same thing the Linux toggle does. A title with a tool already chosen keeps it. Worth deciding whether the receipt should say so.
- The mapping is only as live as the launcher, so Steam started any other way is unmapped *and* ungated. The two failure modes stay together rather than drifting apart.
- Not done here: `--diagnose` does not yet assert the variable reached `steam_osx`.