### PR TITLE
feat(launcher): go and get Valve's client DLL, so the DRM route works at all

### DIFF
--- a/src/compat-tool/steamclient-shim-launch.sh
+++ b/src/compat-tool/steamclient-shim-launch.sh
@@ -238,7 +238,7 @@ for _f in "$SHIM_DIST/$SHIM_PATH_LSTEAM_PE64" "$SHIM_DIST/$SHIM_PATH_LSTEAM_UNIX
     [ -f "$_f" ] || DRM_MISSING="$DRM_MISSING $(basename "$_f")"
 done
 DRM_UNFETCHED=0
-[ -f "$HOME/$SHIM_PATH_CLIENT_CACHE_REL/$SHIM_PATH_PE64" ] || DRM_UNFETCHED=1
+[ -f "$HOME/$SHIM_PATH_CLIENT_DLL_REL" ] || DRM_UNFETCHED=1
 
 HAVE_DRM=0
 [ -z "$DRM_MISSING" ] && [ "$DRM_UNFETCHED" = 0 ] && HAVE_DRM=1
@@ -279,8 +279,8 @@ elif [ "$HAVE_DRM" = 0 ] && shim_drm_enabled && title_is_drm_wrapped "$EXE"; the
     log "         will fail with 'Application load error 3:0000065432'."
     if [ "$DRM_UNFETCHED" = 1 ]; then
         # Beside us in the deployed payload; in the dev tree it is its module's.
-        _fetch="$HERE/fetch.sh"
-        [ -f "$_fetch" ] || _fetch="$HERE/../drm/fetch.sh"
+        _fetch="$HERE/$SHIM_PATH_FETCH_SH"
+        [ -f "$_fetch" ] || _fetch="$HERE/../drm/$SHIM_PATH_FETCH_SH"
         log "         Valve's signed client DLL has not been fetched."
         log "         Run: $_fetch    (downloads ~60 MB from Valve, once)"
     fi
@@ -297,7 +297,7 @@ if [ "$USE_DRM" = 1 ]; then
     # ours would load in its place, silently, and the wrapper would reject the
     # unsigned file it found. The wrapper never looks at the name -- it resolves
     # whatever provided CreateInterface and reads that file.
-    _src="$HOME/$SHIM_PATH_CLIENT_CACHE_REL/$SHIM_PATH_PE64"
+    _src="$HOME/$SHIM_PATH_CLIENT_DLL_REL"
     _dst="$VSTEAMDIR/$SHIM_PATH_VALVE_PE64"
     # Not cp onto the destination: it truncates and rewrites in place, and a
     # concurrently-running wrapped title has that inode mapped. Copy beside it

--- a/src/drm/README.md
+++ b/src/drm/README.md
@@ -21,3 +21,8 @@ The measurement behind it: `docs/research/steam-drm-shared-memory.md`.
 
 `SHIM_DRM=0` turns the route off. Without the fetch it is unavailable and the launch says so.
 Only titles that are actually wrapped take it.
+
+A user never types that first line: the launcher runs this same script for them, before a launch,
+on the first run and from Diagnose (#105). It is the same file either way — this module owns
+Valve's endpoint, the published SHA-256 and the shadow coverage check, and the app owns only the
+question of when to ask.

--- a/src/drm/build.sh
+++ b/src/drm/build.sh
@@ -28,7 +28,7 @@ mkdir -p "$DIST" gen
 CACHE="$HOME/$SHIM_PATH_CLIENT_CACHE_REL"
 
 if [ "${1:-}" = "--regen" ]; then
-    [ -f "$CACHE/$SHIM_PATH_SHADOW_TIER0" ] || ./fetch.sh
+    [ -f "$CACHE/$SHIM_PATH_SHADOW_TIER0" ] || "./$SHIM_PATH_FETCH_SH"
     echo "--- regenerating shadow export lists from Valve's libraries ---"
     python3 gen_shadow.py "$CACHE/$SHIM_PATH_SHADOW_TIER0" \
         gen/tier0_stubs.c gen/tier0.def t0s
@@ -52,7 +52,7 @@ if [ -f "$CACHE/$SHIM_PATH_PE64" ]; then
         "$SHIM_PATH_SHADOW_TIER0"   gen/tier0.def \
         "$SHIM_PATH_SHADOW_VSTDLIB" gen/vstdlib.def
 else
-    echo "drm: no fetched $SHIM_PATH_PE64 to check the shadows against (run ./fetch.sh)"
+    echo "drm: no fetched $SHIM_PATH_PE64 to check the shadows against (run ./$SHIM_PATH_FETCH_SH)"
 fi
 
 $MINGW64 -shared -O2 -Wall -static -static-libgcc -I../layout/gen \

--- a/src/installer/build.sh
+++ b/src/installer/build.sh
@@ -170,7 +170,7 @@ cp -f "$SHIM_DIST_DIR/$SHIM_PATH_LSTEAM_PE64"     "$TOOLDIR/$SHIM_PATH_DIST/"
 cp -f "$SHIM_DIST_DIR/$SHIM_PATH_LSTEAM_UNIX64"   "$TOOLDIR/$SHIM_PATH_DIST/"
 cp -f "$DRM_DIST_DIR/$SHIM_PATH_SHADOW_TIER0"     "$TOOLDIR/$SHIM_PATH_DIST/"
 cp -f "$DRM_DIST_DIR/$SHIM_PATH_SHADOW_VSTDLIB"   "$TOOLDIR/$SHIM_PATH_DIST/"
-cp -f "$REPO/src/drm/fetch.sh"                    "$TOOLDIR/"
+cp -f "$REPO/src/drm/$SHIM_PATH_FETCH_SH"         "$TOOLDIR/"
 cp -f "$REPO/src/drm/check_shadow.py"             "$TOOLDIR/"
 chmod +x "$TOOLDIR/$SHIM_PATH_LAUNCH_SH" "$STAGE/deploy.sh"
 

--- a/src/launcher/AppModel.swift
+++ b/src/launcher/AppModel.swift
@@ -16,6 +16,13 @@ final class AppModel: ObservableObject {
     @Published var launchState: LaunchState = .idle
     @Published var overlay: Bool = Prefs.overlay
     @Published var overlayPendingRestart = false
+    /// Why the last fetch of Valve's client DLL did not work (#105). Kept on
+    /// the model rather than in the row, because the row is recomputed from
+    /// disk — after a failed download the file is still absent, so the check
+    /// would go back to the generic "copy-protected games need a file from
+    /// Valve" and the user would press the same button expecting a different
+    /// result. This is what the row says instead, until something changes it.
+    @Published var valveClientProblem: String?
 
     enum LaunchState: Equatable {
         case idle
@@ -88,7 +95,27 @@ final class AppModel: ObservableObject {
     /// client, so the injector runs in a process that immediately exits.
     var mustQuitSteamFirst: Bool { steamNeedsRestart }
 
+    /// The first-run launch is also where the DRM route gets armed (#105, call
+    /// site 1). A machine that has run this app once should be able to start a
+    /// copy-protected game, and this is the only moment where a user is
+    /// present, has just asked for something, and can be told what is
+    /// happening — the pre-launch site cannot say a word, and Diagnose is
+    /// somewhere most people never open.
+    ///
+    /// It never stops the launch. Offline, the fetcher gives up on the manifest
+    /// in under a minute and Steam starts anyway, which is the correct outcome:
+    /// everything that is not copy-protected works without any of this.
     func launchAndProve() {
+        if ValveClient.mayFetchUnattended {
+            Task.detached {
+                await self.fetchValveClient(then: { self.launchAfterFetch() })
+            }
+            return
+        }
+        launchAfterFetch()
+    }
+
+    private func launchAfterFetch() {
         if mustQuitSteamFirst {
             busy = "Quitting Steam…"
             Task.detached {
@@ -127,6 +154,37 @@ final class AppModel: ObservableObject {
                 self.launchState = .launchedButUnproven(
                     "Steam started, but Steam Play did not switch on. Diagnose has more.")
             }
+        }
+    }
+
+    /// The download, with the fetcher's own narration as the busy label (#105).
+    /// Every call site ends up here: the checklist's button, Diagnose's button,
+    /// and the first run. Detached, because it blocks for as long as 60 MB
+    /// takes; `then` runs on the main actor once it is over, whatever the
+    /// outcome, which is what lets the first run carry on into the launch
+    /// rather than stopping at a failed download.
+    nonisolated func fetchValveClient(then next: (@MainActor () -> Void)? = nil) async {
+        await MainActor.run {
+            self.busy = "Getting Valve's client file…"
+            self.valveClientProblem = nil
+        }
+        let outcome = ValveClient.fetch { line in
+            Task { @MainActor in
+                // Only while this is still the thing on screen: a line arriving
+                // after the user cancelled into something else must not
+                // repaint somebody else's label.
+                if self.busy != nil { self.busy = line }
+            }
+        }
+        await MainActor.run {
+            self.busy = nil
+            if case .failed(let why) = outcome { self.valveClientProblem = why }
+            self.refresh()
+            // Diagnose's list is a snapshot, so the row that offered the button
+            // is stale the moment the button worked — but only re-run it if the
+            // pane is actually showing findings.
+            if !self.findings.isEmpty { self.runDiagnose() }
+            next?()
         }
     }
 

--- a/src/launcher/Diagnose.swift
+++ b/src/launcher/Diagnose.swift
@@ -13,10 +13,17 @@ enum Diagnose {
         let title: String
         let verdict: Verdict
         let detail: String
+        /// A finding used to be a sentence and nothing more, because every row
+        /// here was something the user then went and did elsewhere. The DRM
+        /// download is the first thing this app can do itself (#105), and
+        /// reusing the checklist's `Remedy` is what keeps the two panes from
+        /// growing two different buttons for one job.
+        var remedy: Remedy = .none
+        var remedyTitle: String = ""
     }
 
     static func run() -> [Finding] {
-        [integrity(), strayWindowsSteam(), plainSteam(), overlayState(), compatibility()]
+        [integrity(), strayWindowsSteam(), plainSteam(), overlayState(), valveClient(), compatibility()]
     }
 
     /// Is what is on disk what was shipped? The deploy module answers, because
@@ -91,6 +98,41 @@ enum Diagnose {
                        // panel opens is Steam's business and a user finds out by
                        // pressing Shift+Tab, not by reading about a handshake.
                        detail: loaded ? "" : "Try starting the game again.")
+    }
+
+    /// Valve's signed client DLL, and the one row in either pane that offers to
+    /// go and get something (ADR 0014, #105).
+    ///
+    /// It is here, and not only on the checklist, because it goes stale: a
+    /// Steam client update replaces that DLL, and a machine that fetched
+    /// happily in June is holding what the June client wanted. `fetch.sh`
+    /// settles it — it re-reads Valve's manifest and compares the published
+    /// SHA-256, which is what makes re-running it cheap when nothing has
+    /// changed — but the settling costs a round trip, so the app does not spend
+    /// a user's bandwidth on its own initiative. It offers the button instead,
+    /// in the window someone opens when a game has stopped starting.
+    ///
+    /// Which is why the ok row keeps its button rather than latching green: a
+    /// row that says "fine" and offers nothing is a dead end for exactly the
+    /// user this row exists for.
+    static func valveClient() -> Finding {
+        guard ShimPolicy.shimDrmEnabled() else {
+            return Finding(id: ValveClient.rowID, title: "Copy protection support is switched off",
+                           verdict: .ok,
+                           detail: "This Mac is set to launch copy-protected games the normal way, "
+                                 + "so nothing needs downloading from Valve.")
+        }
+        guard ValveClient.isCached else {
+            return Finding(id: ValveClient.rowID, title: "Copy-protected games cannot start yet",
+                           verdict: .warning,
+                           detail: ValveClient.why,
+                           remedy: .fetchValveClient, remedyTitle: "Download it")
+        }
+        return Finding(id: ValveClient.rowID, title: "Valve's client file is here",
+                       verdict: .ok,
+                       detail: "If a copy-protected game stopped starting after a Steam update, "
+                             + "get it again — it is quick when nothing has changed.",
+                       remedy: .fetchValveClient, remedyTitle: "Get it again")
     }
 
     /// What this build was measured against, beside what this Mac is. Both come

--- a/src/launcher/Preflight.swift
+++ b/src/launcher/Preflight.swift
@@ -25,6 +25,12 @@ enum Remedy: Equatable {
     /// that the app is already there.
     case openApp(String)
     case createBottle
+    /// Run the DRM module's downloader, with its progress on screen (#105).
+    /// The other cases hand the job to somebody else and are done in a frame;
+    /// this one is ours, takes a minute, and can fail for a reason the user has
+    /// to be told — which is why it is a case here rather than an `openURL` at
+    /// a page explaining how to run a shell script.
+    case fetchValveClient
     case reinstall
     case none
 }
@@ -40,7 +46,7 @@ struct Check: Identifiable, Equatable {
 
 enum Preflight {
     /// The whole list, in the order the checklist shows it. Cheap enough to run
-    /// on every launch: six stats and one small file read.
+    /// on every launch: seven stats and one small file read.
     ///
     /// Deliberately free of subprocesses. `liveProof` — whether a Steam that is
     /// up right now has Steam Play on — costs a `ps` and a `pgrep`, so the
@@ -48,7 +54,14 @@ enum Preflight {
     /// here would put a process spawn inside a SwiftUI view update, which is
     /// both slow on every render and how this crashed once already.
     static func run(liveProof: Bool = false) -> [Check] {
-        [system(), crossover(), steam(), bottle(), payload(), selfVerification(liveProof: liveProof)]
+        var list = [system(), crossover(), steam(), bottle(), payload()]
+        // Only when the route it serves is switched on. With SHIM_DRM=0 the
+        // launch script will not take that route however well armed it is, so a
+        // row about a missing download would be asking for 60 MB to satisfy a
+        // check that nothing reads.
+        if ShimPolicy.shimDrmEnabled() { list.append(valveClient()) }
+        list.append(selfVerification(liveProof: liveProof))
+        return list
     }
 
     /// The question the happy path asks. A blocked check means the user clicked
@@ -206,7 +219,30 @@ enum Preflight {
         return Check(id: "payload", title: "Steam Play files ready", verdict: .ok, detail: "")
     }
 
-    // 6 — the one check that cannot be made before a launch. The user never
+    // 6 — Valve's own signed client DLL, the only thing in this list that is
+    // not on the machine because we put it there (ADR 0014, #105). One stat, as
+    // cheap as the five above it; the download itself hangs off the remedy,
+    // which is what keeps this file free of the network.
+    //
+    // A warning and never blocked: the rest of the library runs without it, and
+    // stopping a user whose games all work in order to demand 60 MB for the
+    // ones they may not own would be this app inventing a problem. It is the
+    // same interlock the payload already states for a missing shadow — deploys
+    // fine, and leaves DRM-wrapped titles failing as they did before.
+    static func valveClient() -> Check {
+        guard ValveClient.isCached else {
+            return Check(id: ValveClient.rowID,
+                         title: "Copy-protected games need one file from Valve",
+                         verdict: .warning,
+                         detail: ValveClient.why,
+                         remedy: .fetchValveClient,
+                         remedyTitle: "Download it")
+        }
+        return Check(id: ValveClient.rowID, title: "Valve's client file is here",
+                     verdict: .ok, detail: "")
+    }
+
+    // 7 — the one check that cannot be made before a launch. The user never
     // reads a log for `patched 1 site(s)`; the app reads it and says "ready".
     static func selfVerification(liveProof: Bool) -> Check {
         // A client that is up right now with Steam Play switched on is the

--- a/src/launcher/Prefs.swift
+++ b/src/launcher/Prefs.swift
@@ -41,7 +41,23 @@ enum Prefs {
         set { store.set(newValue, forKey: firstRunKey) }
     }
 
+    /// When the unattended fetch of Valve's client DLL last ran (#105).
+    ///
+    /// Stored for one reason: the pre-launch call site starts that download
+    /// with nobody watching, and a machine with no network would otherwise
+    /// spawn a doomed curl on every single Steam launch, forever, saying
+    /// nothing. A day between silent attempts is enough to arm a machine that
+    /// comes back online without turning a network outage into a background
+    /// job that never stops. A user pressing the button in either pane is
+    /// asking explicitly and is never throttled by this.
+    static var lastClientFetch: Date? {
+        get { store.object(forKey: clientFetchKey) as? Date }
+        set { store.set(newValue, forKey: clientFetchKey) }
+    }
+
+    private static let clientFetchKey = "lastClientFetch"
+
     static func forget() {
-        for key in [overlayKey, firstRunKey] { store.removeObject(forKey: key) }
+        for key in [overlayKey, firstRunKey, clientFetchKey] { store.removeObject(forKey: key) }
     }
 }

--- a/src/launcher/README.md
+++ b/src/launcher/README.md
@@ -22,12 +22,31 @@ before.
 |---|---|
 | `main.swift` | mode dispatch, and the exec that ends the process |
 | `Launch.swift` | the child environment: the DYLD merge (#85), the tool path, the stated overlay |
-| `Preflight.swift` | the six checks, as verdicts a user can act on |
+| `Preflight.swift` | the seven checks, as verdicts a user can act on |
 | `LogWatch.swift` | reads `patched 1 site(s)` so the user never has to |
 | `Diagnose.swift` | the README's troubleshooting table, executed |
+| `ValveClient.swift` | runs `src/drm/fetch.sh`, from the three places that arm the DRM route (#105) |
 | `Receipt.swift` / `Prefs.swift` | what is deployed (ADR 0010), and what the user chose |
 | `AppModel.swift` / `UI.swift` | the two panes |
 | `check_launch_env.sh` | #85's acceptance test, run by `build.sh` on every build |
+
+## The one thing here that touches the network
+
+The DRM route needs Valve's own signed client DLL, which we may not ship (ADR
+0014). Nothing ever went and got it, so the route was dead on every fresh
+machine (#105). `ValveClient.swift` is the trigger, and it runs the DRM
+module's `fetch.sh` rather than learning to talk to Valve's manifest itself:
+
+| where | when | who watches |
+|---|---|---|
+| `main.swift`, before the exec | the cache is empty | nobody — started and orphaned, so the click still means "start Steam" |
+| the checklist's first-run launch | the cache is empty | the user, in the busy line, and the launch happens either way |
+| Diagnose | the button is pressed, including on a green row | the user — this is the re-fetch after a Steam client update |
+
+`Preflight` stays stat-only: it asks whether the cached file exists, never
+whether it is current. Deciding *that* costs a round trip to Valve, so the app
+never spends a user's bandwidth on its own initiative — which is why the green
+row in Diagnose keeps its button instead of latching.
 
 ## Why it is compiled, and why locally
 

--- a/src/launcher/Shell.swift
+++ b/src/launcher/Shell.swift
@@ -2,11 +2,14 @@ import Foundation
 
 /// Running a command and keeping what it said.
 ///
-/// The launcher shells out for exactly three things, all of them owned by
+/// The launcher shells out for exactly four things, all of them owned by
 /// somebody else: `deploy.sh` (verify, uninstall, rollback — ADR 0010 says the
 /// deploy module owns those, so reimplementing them here would be a second
-/// implementation that can disagree), `cxbottle` (CodeWeavers' bottle creation,
-/// whose incantation this app exists to keep out of the README), and `pgrep`.
+/// implementation that can disagree), `fetch.sh` (the DRM module's downloader —
+/// it owns Valve's manifest, the published SHA-256 and the shadow coverage
+/// check, and none of that gets a second implementation either), `cxbottle`
+/// (CodeWeavers' bottle creation, whose incantation this app exists to keep out
+/// of the README), and `pgrep`.
 enum Shell {
     struct Result {
         let status: Int32
@@ -35,6 +38,50 @@ enum Shell {
         proc.waitUntilExit()
         return Result(status: proc.terminationStatus,
                       output: String(data: data, encoding: .utf8) ?? "")
+    }
+
+    /// The same thing, for a command slow enough that its silence is the
+    /// problem. `run` hands back everything at once, which is right for a
+    /// verify that takes a second and wrong for a 60 MB download: `onLine`
+    /// fires as each line arrives, so the label under the spinner can say which
+    /// step is running rather than "Working…" for a minute (#105).
+    ///
+    /// Blocking, like `run`, and on the caller's thread — never the main one.
+    @discardableResult
+    static func stream(_ path: String, _ args: [String],
+                       onLine: @escaping (String) -> Void) -> Result {
+        guard FileManager.default.isExecutableFile(atPath: path) else {
+            return Result(status: 127, output: "\(path): not executable")
+        }
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: path)
+        proc.arguments = args
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = pipe
+        do { try proc.run() } catch {
+            return Result(status: 127, output: "\(path): \(error.localizedDescription)")
+        }
+        // Read as it comes, for the same reason `run` reads before waiting: a
+        // child that fills the pipe while nobody drains it stops there. The
+        // whole output is kept too, because a failure is explained by what was
+        // said last, not by the exit code alone.
+        var output = ""
+        var pending = ""
+        let handle = pipe.fileHandleForReading
+        while case let chunk = handle.availableData, !chunk.isEmpty {
+            let text = String(data: chunk, encoding: .utf8) ?? ""
+            output += text
+            pending += text
+            // A read can end mid-line, so the tail is carried to the next one
+            // rather than reported as a line of its own.
+            let parts = pending.components(separatedBy: "\n")
+            pending = parts.last ?? ""
+            for line in parts.dropLast() where !line.isEmpty { onLine(line) }
+        }
+        if !pending.isEmpty { onLine(pending) }
+        proc.waitUntilExit()
+        return Result(status: proc.terminationStatus, output: output)
     }
 
     static func isRunning(_ pattern: String) -> Bool {

--- a/src/launcher/UI.swift
+++ b/src/launcher/UI.swift
@@ -168,6 +168,37 @@ struct Hairline: View {
     var body: some View { Divider().opacity(0.5).padding(.leading, 44) }
 }
 
+/// A row's remedy, wherever the row is shown. Shared between the two panes
+/// because a remedy is a property of the check, not of the pane: the DRM
+/// download appears on the checklist and in Diagnose, and one button drawn
+/// twice is how the two would end up disagreeing about what it does (#105).
+struct RemedyButton: View {
+    let remedy: Remedy
+    let title: String
+    @ObservedObject var model: AppModel
+
+    var body: some View {
+        switch remedy {
+        case .openURL(let url): Link(title, destination: url)
+        case .openApp(let path):
+            Button(title) { NSWorkspace.shared.open(URL(fileURLWithPath: path)) }
+        case .createBottle: Button(title) { model.createBottle() }.disabled(model.busy != nil)
+        case .fetchValveClient:
+            Button(title) { Task { await model.fetchValveClient() } }.disabled(model.busy != nil)
+        case .reinstall: Button(title) { Help.showReinstall() }
+        case .none: EmptyView()
+        }
+    }
+}
+
+/// What a row says, once the model knows better than the row does. Only the
+/// DRM download has anything to add: its check is a stat, so after a failed
+/// fetch the file is still missing and the row would go back to explaining why
+/// it is needed — while what the user needs to read is why it did not arrive.
+@MainActor private func rowDetail(_ id: String, _ detail: String, _ model: AppModel) -> String {
+    id == ValveClient.rowID ? (model.valveClientProblem ?? detail) : detail
+}
+
 // MARK: - checklist (first run, or preflight broken)
 
 struct ChecklistView: View {
@@ -180,8 +211,9 @@ struct ChecklistView: View {
                 Card {
                     ForEach(Array(model.checks.enumerated()), id: \.element.id) { index, check in
                         let shown = displayed(check)
-                        StatusRow(verdict: shown.verdict, title: shown.title, detail: shown.detail) {
-                            remedy(for: check)
+                        StatusRow(verdict: shown.verdict, title: shown.title,
+                                  detail: rowDetail(shown.id, shown.detail, model)) {
+                            RemedyButton(remedy: check.remedy, title: check.remedyTitle, model: model)
                         }
                         if index < model.checks.count - 1 { Hairline() }
                     }
@@ -296,20 +328,6 @@ struct ChecklistView: View {
             return Check(id: check.id, title: "Steam Play did not switch on", verdict: .blocked, detail: why)
         case .idle:
             return check
-        }
-    }
-
-    @ViewBuilder
-    private func remedy(for check: Check) -> some View {
-        switch check.remedy {
-        case .openURL(let url): Link(check.remedyTitle, destination: url)
-        case .openApp(let path):
-            Button(check.remedyTitle) {
-                NSWorkspace.shared.open(URL(fileURLWithPath: path))
-            }
-        case .createBottle: Button(check.remedyTitle) { model.createBottle() }.disabled(model.busy != nil)
-        case .reinstall: Button(check.remedyTitle) { Help.showReinstall() }
-        case .none: EmptyView()
         }
     }
 }
@@ -507,7 +525,10 @@ struct DiagnoseTab: View {
             } else {
                 Card {
                     ForEach(Array(model.findings.enumerated()), id: \.element.id) { index, f in
-                        StatusRow(verdict: f.verdict, title: f.title, detail: f.detail) { EmptyView() }
+                        StatusRow(verdict: f.verdict, title: f.title,
+                                  detail: rowDetail(f.id, f.detail, model)) {
+                            RemedyButton(remedy: f.remedy, title: f.remedyTitle, model: model)
+                        }
                         if index < model.findings.count - 1 { Hairline() }
                     }
                 }

--- a/src/launcher/ValveClient.swift
+++ b/src/launcher/ValveClient.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Valve's own signed `steamclient64.dll`, and the one job in this app that
+/// needs the network (ADR 0014, #105).
+///
+/// It is the single file of the DRM route that we do not ship and cannot: the
+/// wrapper reads whichever file provided `CreateInterface` and verifies Valve's
+/// signature over its bytes, and we are not allowed to pass Valve's bytes on.
+/// So the app goes and gets it, from Valve's own public client manifest, to
+/// this machine — which is what `src/drm/fetch.sh` does, and until #105 nothing
+/// ever called it. Every caller here runs that one script rather than learning
+/// to talk to Valve's manifest itself: it is the half that knows the endpoint,
+/// verifies the published SHA-256, and checks our shadows against the client
+/// build the user will actually run.
+///
+/// The cheap/expensive split is the cache, and it already existed. This is the
+/// side that fills it, once; the launch script copies out of it into the bottle
+/// per launch and skips even that when the sizes match. So "is the route armed"
+/// is a stat, and only a cold machine pays for the download.
+enum ValveClient {
+    /// Beside the versions rather than inside one, so a deploy does not throw
+    /// away 60 MB the user already paid for.
+    static var cachedDLL: String { ShimPath.inHome(ShimPath.clientDllRel) }
+    static var fetcher: String { ShimPath.inHome(ShimPath.fetchShRel) }
+
+    /// The whole check, and cheap enough for `Preflight` to ask on every
+    /// launch: one `stat`, no hashing and no network. Whether the cached copy
+    /// is still the one this Steam client wants is `fetch.sh`'s question — it
+    /// re-reads the manifest and compares Valve's published SHA-256 — and
+    /// asking it costs a round trip, which is why it is never asked here.
+    static var isCached: Bool { FileManager.default.fileExists(atPath: cachedDLL) }
+
+    /// The id both the preflight row and the Diagnose row carry, so the pane
+    /// that showed the button knows which row the failure belongs in.
+    static let rowID = "valveClient"
+
+    /// Why a game launcher is downloading 60 MB of Steam. Asking for that
+    /// without a reason reads badly, and the reason is not embarrassing: it is
+    /// the same sentence `fetch.sh`'s header opens with.
+    static let why = "Steam's copy protection checks Valve's signature on Valve's own "
+                   + "client file, and nobody but Valve may pass that file on — so it "
+                   + "comes to you from Valve, about 60 MB, once per Steam client update."
+
+    /// What `fetch.sh` prefixes its own lines with, as opposed to the output
+    /// of the checker it calls.
+    private static let narration = "drm-fetch: "
+
+    enum Outcome: Equatable {
+        case ok             // fetched, or already current — the route is armed
+        case failed(String) // a sentence for the row that offered the button
+    }
+
+    /// Run the fetcher and watch it talk. `progress` gets each line it prints,
+    /// which is what turns "the app is thinking" into "downloading 60 MB from
+    /// Valve" — the script already narrates its three slow steps, so nothing
+    /// here has to estimate anything.
+    ///
+    /// Blocking, and never to be called on the main thread.
+    static func fetch(progress: @escaping (String) -> Void) -> Outcome {
+        guard FileManager.default.isExecutableFile(atPath: fetcher) else {
+            return .failed("The downloader is missing from this install. Reinstall to put it back.")
+        }
+        // Recorded before it runs, and whatever happens next: what this
+        // timestamp gates is the UNATTENDED retry, so a failure has to count.
+        Prefs.lastClientFetch = Date()
+        var last = ""
+        let result = Shell.stream(fetcher, []) { line in
+            // Its own narration only. `drm-fetch:` is a prefix for a log, not
+            // for a label under a spinner — and the lines WITHOUT it come from
+            // the shadow coverage checker it calls, which reports in full paths
+            // and import counts. True, useful in a terminal, and not a sentence
+            // to put in front of a user.
+            guard line.hasPrefix(narration) else { return }
+            let text = String(line.dropFirst(narration.count))
+            guard !text.isEmpty else { return }
+            last = text
+            progress(text)
+        }
+        if result.ok { return .ok }
+        return .failed(explain(result.status, last: last))
+    }
+
+    /// Start it and walk away — the pre-launch call site, where the user asked
+    /// for Steam and not for a download. Orphaning it is deliberate: this
+    /// process is about to `execve` into `steam_osx`, and the fetch outlives
+    /// that. Nothing reports the result, because there is nobody to report it
+    /// to; the next time a window opens, the two rows say where it got to.
+    static func fetchDetached() {
+        Prefs.lastClientFetch = Date()
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: fetcher)
+        // Its own log lines are the only trace, and there is no window to put
+        // them in. /dev/null rather than a pipe: a pipe with no reader fills
+        // and stops the download at 64 KB.
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        try? proc.run()
+    }
+
+    /// Whether the unattended path should try at all. It exists because the
+    /// failure it guards against is silent and repeating: with no network,
+    /// every single Steam launch would otherwise spawn a curl that cannot
+    /// succeed, and with a network that drops mid-download it would re-spend
+    /// 60 MB each time. A user who clicks the button is asking explicitly and
+    /// is never throttled.
+    static var mayFetchUnattended: Bool {
+        guard ShimPolicy.shimDrmEnabled(), !isCached,
+              FileManager.default.isExecutableFile(atPath: fetcher) else { return false }
+        guard let last = Prefs.lastClientFetch else { return true }
+        return Date().timeIntervalSince(last) > 24 * 60 * 60
+    }
+
+    /// `fetch.sh`'s exit codes, as sentences. A non-zero exit is not an answer
+    /// a user can act on, and the four failures are four different situations:
+    /// one is their network, one is Valve moving something, one is a file that
+    /// arrived wrong, and one is us being out of date while the files are in
+    /// fact installed.
+    private static func explain(_ status: Int32, last: String) -> String {
+        switch status {
+        case 3:
+            return "Could not reach Valve. Check your internet connection and try again. "
+                 + "Everything else works without this; only copy-protected games need it."
+        case 4:
+            return "What arrived from Valve did not match what Valve says it should be, "
+                 + "so it was thrown away. Try again later."
+        case 5:
+            // The DLLs are on disk and this is a coverage failure against THIS
+            // client build (fetch.sh's check_shadow.py). Saying "failed" would
+            // send the user to retry a download that already succeeded.
+            return "Valve's file is here, but this Steam client build needs a newer "
+                 + "version of this app before copy-protected games can use it."
+        case 2, 127:
+            return "The downloader is missing from this install. Reinstall to put it back."
+        default:
+            return last.isEmpty ? "The download did not finish." : last
+        }
+    }
+}

--- a/src/launcher/build.sh
+++ b/src/launcher/build.sh
@@ -32,8 +32,8 @@ swiftc -O -swift-version 5 \
     -o "$OUT/$SHIM_PATH_LAUNCHER_BIN" \
     ../layout/gen/ShimPaths.swift \
     ../layout/gen/ShimPolicy.swift \
-    Shell.swift Prefs.swift Receipt.swift LogWatch.swift Preflight.swift \
-    Diagnose.swift Launch.swift AppModel.swift UI.swift \
+    Shell.swift Prefs.swift Receipt.swift LogWatch.swift ValveClient.swift \
+    Preflight.swift Diagnose.swift Launch.swift AppModel.swift UI.swift \
     main.swift
 
 # Ad-hoc, like the injector dylib beside it. There is no Developer ID yet; when

--- a/src/launcher/main.swift
+++ b/src/launcher/main.swift
@@ -69,6 +69,18 @@ let neverLaunched = !Prefs.firstRunCompleted
 let checks = Preflight.run(liveProof: liveProof)
 
 if !wantsSettings && !optionHeld && !neverLaunched && Preflight.isClear(checks) {
+    // Before Steam starts, arm the DRM route if it is not armed (#105, call
+    // site 3). On every launch but the first this is the stat preflight has
+    // just done and nothing happens: the cache is filled once and sits beside
+    // the versions, so it survives every deploy after it.
+    //
+    // Started and left to run, never waited for. The click means "start
+    // Steam", and a 60 MB download in front of that is this app doing the one
+    // thing its prime rule forbids. The fetcher outlives the exec below —
+    // launchd adopts it — and the two rows in the windows report where it got
+    // to, next time a window opens. Throttled, because nobody is watching:
+    // see Prefs.lastClientFetch.
+    if ValveClient.mayFetchUnattended { ValveClient.fetchDetached() }
     Launch.exec(passthrough: passthrough, overlay: Prefs.overlay)   // never returns
 }
 

--- a/src/layout/layout.json
+++ b/src/layout/layout.json
@@ -73,7 +73,8 @@
     { "name": "VSTEAM_SUBDIR", "value": "drive_c/vsteam",      "what": "the same dir relative to the bottle, unix side", "guard": true },
     { "name": "CLIENT_CACHE",  "value": "valve-client",        "what": "payload subdir holding the Valve DLLs fetched from Valve's public client manifest. Beside the versions, not inside one: it outlives any single deploy and a re-download is expensive", "guard": true },
     { "name": "CLIENT_MANIFEST_URL", "value": "https://media.steampowered.com/client/steam_client_win32", "what": "Valve's own public, unauthenticated Windows client manifest — the same one steamcmd bootstraps from. Names the packages, their sizes and their SHA-256s", "guard": true },
-    { "name": "CLIENT_PKG",    "value": "bins_win32",          "what": "the package in that manifest carrying steamclient64.dll, tier0_s64.dll and vstdlib_s64.dll", "guard": true }
+    { "name": "CLIENT_PKG",    "value": "bins_win32",          "what": "the package in that manifest carrying steamclient64.dll, tier0_s64.dll and vstdlib_s64.dll", "guard": true },
+    { "name": "FETCH_SH",      "value": "fetch.sh",            "what": "the downloader that fills that cache, deployed beside the launch script. A contract name because the app runs it: the launcher, Diagnose and the pre-launch check all invoke this one file rather than each knowing how to talk to Valve's manifest (#105)", "guard": true }
   ],
 
   "joins": [
@@ -95,7 +96,9 @@
 
     { "name": "VALVE_PE64_WIN",   "of": ["VSTEAM_DIR_WIN", "VALVE_PE64"], "sep": "win", "what": "what SteamClientDll64 points at on the DRM route: VALVE'S signed DLL, not ours" },
     { "name": "LSTEAM_PE64_WIN",  "of": ["SHIM_DIR_WIN", "LSTEAM_PE64"], "sep": "win", "what": "the shim under its second name, which the trampolines load" },
-    { "name": "CLIENT_CACHE_REL", "of": ["PAYLOAD_REL", "CLIENT_CACHE"], "sep": "posix", "what": "the fetched Valve DLLs, relative to $HOME" }
+    { "name": "CLIENT_CACHE_REL", "of": ["PAYLOAD_REL", "CLIENT_CACHE"], "sep": "posix", "what": "the fetched Valve DLLs, relative to $HOME" },
+    { "name": "CLIENT_DLL_REL",   "of": ["CLIENT_CACHE_REL", "PE64"], "sep": "posix", "what": "Valve's signed client DLL in that cache, relative to $HOME. The one file of the DRM route that we do not ship and cannot: 'has the fetch run on this machine' is a stat of exactly this path, and it is asked from the launch script, the preflight list and Diagnose" },
+    { "name": "FETCH_SH_REL",     "of": ["TOOL_DIR_REL", "FETCH_SH"], "sep": "posix", "what": "the deployed downloader, relative to $HOME — what the launcher app execs when the cache is empty" }
   ],
 
   "switches": [


### PR DESCRIPTION
`fetch.sh` shipped in the payload and was invoked by nothing, so on a fresh machine the DRM route could never engage. This wires up the trigger from the three places #105 names, without moving the cache or touching the per-launch copy into the bottle.

## The design

**One cache, three triggers.** The cheap/expensive split already existed and is untouched: `ShimPaths.clientCache` is filled once, and `steamclient-shim-launch.sh` still copies out of it per launch and still skips that copy when the sizes match.

| call site | when it fetches | who watches |
|---|---|---|
| `main.swift`, immediately before the `execve` | the cache is empty | nobody — the process is started and orphaned, so the click still means "start Steam" |
| the checklist's first-run launch (`AppModel.launchAndProve`) | the cache is empty | the user, in the busy line; the launch happens either way |
| Diagnose | the button is pressed, **including on a green row** | the user — this is the re-fetch after a Steam client update |

**`Preflight` stays stat-only.** The new check 6 is a `FileManager.fileExists` on the cached DLL, as cheap as the five beside it. No hashing, no subprocess, no network in that file. Verdict is `.warning`, never `.blocked`. The row is omitted entirely when `shim_drm_enabled()` says the route is off — asking for 60 MB to satisfy a check nothing reads would be pure noise.

**`Remedy.fetchValveClient`** is the new case, because none of the five could do this. `Shell.stream` is `Shell.run`'s sibling that hands each line to a callback as it arrives, so the busy label says "downloading bins_win32.zip… (~60 MB)" instead of nothing for a minute. `fetch.sh`'s exit codes become four different sentences — notably exit 5 (this Steam client build outgrew our shadows) is *not* a failed download and must not tell the user to retry one. Only the script's own `drm-fetch:` lines reach the label; the shadow checker's output underneath it is full paths and import counts, which is a log, not a sentence.

**Staleness is user-triggered, as #105 decided.** Nothing re-fetches on its own initiative. The Diagnose row keeps its button when it is green, so there is somewhere to click after a client update; whether the cached copy is current is `fetch.sh`'s question and costs a round trip, so it is never asked from a checklist.

**Offline never stops anything.** The first-run fetch fails inside a minute and Steam starts anyway. The unattended pre-launch fetch is throttled to one attempt a day (`Prefs.lastClientFetch`) — without it, a Mac with no network spawns a doomed `curl` on every single Steam launch, silently, forever. A user pressing either button is never throttled.

**Failure text survives the re-check.** The check is a stat, so after a failed download the file is still missing and the row would revert to the generic "why we need this". `AppModel.valveClientProblem` is what the row says instead, until something changes it.

## Contract

`fetch.sh` and the cached DLL had no manifest names, so the first commit adds `FETCH_SH` (guarded) and the joins `FETCH_SH_REL` / `CLIENT_DLL_REL`. Guarding it turned up four sites that already spelled the literal out, including the launch script's own "Run: …/fetch.sh" hint; two more composed `CLIENT_CACHE_REL` + `PE64` by hand. All now read the generated name. No values changed.

## What I verified

- `src/launcher/build.sh` — compiles clean, and its `check_launch_env.sh` acceptance test (the `DYLD_INSERT_LIBRARIES` merge, #85) still passes.
- `src/installer/build.sh` end to end, i.e. every gate CI runs, plus `dist/payload/deploy.sh --dry-run` and the version stamp. `fetch.sh` is still staged into the compat-tool dir, still executable, and at exactly the path `FETCH_SH_REL` names on this machine's deployed 0.3.1.
- `sh -n` on the launch script.
- **I did run the real fetch, once** (the issue allows it; it is idempotent). Driven through `ValveClient.fetch` from a small throwaway harness compiled against the same sources, not through the GUI:
  - cold: manifest read → 60 MB download → SHA-256 verified → installed → both shadows cover all 165 and 130 imports of *this* client build → `outcome: ok`, cache present.
  - warm, immediately after: `already at 8b712b2… -- nothing to do`, `outcome: ok`. That is the "Get it again" path, and it is a couple of seconds.
- `./dist/launcher --diagnose` before and after: the row reads `[warning] Copy-protected games cannot start yet` with the why-copy, then `[ok] Valve's client file is here` with the re-fetch prompt.

## What I did not verify

- Anything that needs the GUI: no button was ever clicked, no busy label ever rendered, no SwiftUI update observed. The three call sites compile and their non-UI halves were exercised directly; the wiring from `RemedyButton` into `AppModel.fetchValveClient` is compiled-and-reviewed only.
- The failure branches. Exit 3 (offline), 4 (SHA mismatch) and 5 (shadow coverage) were not provoked — the mapping from exit code to sentence is read, not measured.
- That a DRM-wrapped title now launches on a machine armed this way. That is #104's territory as much as this one's, and I did not touch detection.

## Worth a separate issue

`Shell.run`'s `timeout:` parameter is **not implemented** — it is accepted and never used, so `Preflight.createBottle(timeout: 300)` has no timeout and never had one. I left it alone rather than widening this PR. `Shell.stream` inherits the same gap; in practice `fetch.sh`'s `curl` calls carry their own `--max-time`, so the fetch is bounded even though nothing here bounds it.

Closes #105.
