### PR TITLE
fix(compat-tool): arm the DRM route from the title, not from the binary Steam names

### DIFF
--- a/docs/adr/0014-drm-titles-run-through-valves-own-signed-client-dll.md
+++ b/docs/adr/0014-drm-titles-run-through-valves-own-signed-client-dll.md
@@ -134,3 +134,31 @@ wrapped title fails as it does today rather than losing the working 32-bit route
 manifest SHA-256 gates it) and could in principle change the import set (`check_shadow.py`). A title
 update re-applies the wrapper, and the `.bind` layout could change. Both are named in the research
 doc's `re-verify-on`.
+
+## Amendment, 2026-09-05: the question is asked of the *title*, not of the file Steam names (#104)
+
+The decision stands. What did not hold is the assumption inside part 3 — that the file Steam hands
+the compat tool is the file to read the section table of.
+
+Warhammer 40,000: Space Marine II is launched through a 32-bit outer launcher with no `.bind`
+section at all; two of its eight EXEs are wrapped, and the one the game actually runs is four
+directories down. So the route never armed through Steam, and neither did the warning, because both
+asked the same question about the same wrong file. #97's proof launched the wrapped binary directly,
+where `$EXE` *was* the wrapped file — true, and not measured through this path.
+
+Two changes, both in `steamclient-shim-launch.sh`:
+
+- **The arming signal is now "does this title ship a wrapped binary"** — a capped, scoped sweep of
+  the title's install directory (`STEAM_COMPAT_INSTALL_PATH`) for any EXE carrying `.bind`, with the
+  launcher's `ApplicationPath` ini followed first as a *refinement* that nothing depends on. This
+  widens "only wrapped titles take it" from a file to a title: a title shipping a wrapped EXE it
+  does not launch will arm the route and lose its overlay. Over-arming is visible in the log and
+  recoverable; under-arming is a title that cannot start at all.
+- **The bitness gate moved out of the wrapped test to its call site.** "Is this file wrapped" is a
+  fact about bytes; "can our route help it" is a fact about the route. Merged, they made a 32-bit
+  launcher fronting a wrapped 64-bit title indistinguishable from an ordinary unwrapped 32-bit one,
+  and "wrapped, but we cannot help it" unsayable. The 64-bit-only consequence above is unchanged;
+  it is now stated to the user instead of returning silently.
+
+Both are interim. #107 removes the prediction entirely by arming the route once per bottle the way
+Proton does, at which point the sweep is deleted and the split questions survive as diagnostics.

--- a/src/compat-tool/steamclient-shim-launch.sh
+++ b/src/compat-tool/steamclient-shim-launch.sh
@@ -243,21 +243,50 @@ DRM_UNFETCHED=0
 HAVE_DRM=0
 [ -z "$DRM_MISSING" ] && [ "$DRM_UNFETCHED" = 0 ] && HAVE_DRM=1
 
+# --- is this TITLE wrapped? (#104) --------------------------------------------
 # Steam's DRM wrapper lives in a `.bind` section, and it is in the file on disk
-# rather than unpacked at runtime -- so the section table answers "is this title
-# wrapped" exactly, without running anything. Any failure to read it means NO:
-# taking the normal path for a wrapped title produces one legible error dialog,
-# while taking the DRM path for an unwrapped one changes a launch that works.
-title_is_drm_wrapped() {
-    _exe="$1" _lfanew= _nsec= _szopt= _start= _machine=
+# rather than unpacked at runtime -- so the section table answers exactly,
+# without running anything (ADR 0014). Any failure to read a file means NO for
+# that file: taking the normal path for a wrapped title produces one legible
+# error dialog, while taking the DRM path for an unwrapped one changes a launch
+# that works.
+#
+# What changed in #104 is WHICH FILE is asked. This used to ask about $EXE, the
+# binary Steam hands the compat tool -- and for Space Marine II that is a 32-bit
+# outer launcher with no `.bind` at all, while the wrapped binary sits four
+# directories down. Measured there: two of the title's eight EXEs are wrapped,
+# neither of them the one Steam names. So the route never armed, and neither
+# did the warning that would have explained it, because both asked the same
+# question about the same wrong file.
+#
+# "Is this file wrapped" is a fact about a file. "Does this title ship a wrapped
+# binary" is a fact about the title -- and the route is armed per title.
+
+# Two questions that used to be one function. The second is "can our route help
+# it": the shadows, the second shim name and the trampolines are all 64-bit, so
+# a 32-bit wrapped title would take a route that cannot help it and lose the
+# working 32-bit one. Merged into the wrapped test, that gate made a 32-bit
+# launcher fronting a wrapped 64-bit title indistinguishable from an ordinary
+# unwrapped 32-bit title -- the test returned at the bitness check before it
+# ever read a section table, and "wrapped, but we cannot help it" was not
+# sayable. The gate now lives at the call site, where it can be said out loud.
+PE_MACHINE_AMD64=34404          # IMAGE_FILE_MACHINE_AMD64 (0x8664), decimal
+
+# One pass over the headers answers both, because every od and dd is a process
+# spawn and the sweep below asks this of every EXE the title ships. Sets
+# EXE_MACHINE (COFF machine word) and EXE_WRAPPED (1 = carries `.bind`);
+# non-zero return means the file is not a PE we could read, which is a NO.
+EXE_MACHINE=
+EXE_WRAPPED=0
+exe_read_pe() {
+    _exe="$1" _lfanew= _nsec= _szopt= _start=
+    EXE_MACHINE=
+    EXE_WRAPPED=0
     [ -f "$_exe" ] || return 1
     _lfanew=$(od -An -tu4 -j 60 -N 4 "$_exe" 2>/dev/null | tr -d ' ') || return 1
     [ -n "$_lfanew" ] && [ "$_lfanew" -gt 0 ] 2>/dev/null || return 1
-    # 64-bit only. The shadows, the second shim name and the trampolines are all
-    # 64-bit, so a 32-bit wrapped title would take a route that cannot help it
-    # and lose the working 32-bit one. 0x8664 = IMAGE_FILE_MACHINE_AMD64.
-    _machine=$(od -An -tu2 -j $((_lfanew + 4)) -N 2 "$_exe" 2>/dev/null | tr -d ' ')
-    [ "$_machine" = "34404" ] || return 1
+    EXE_MACHINE=$(od -An -tu2 -j $((_lfanew + 4)) -N 2 "$_exe" 2>/dev/null | tr -d ' ') || return 1
+    [ -n "$EXE_MACHINE" ] || return 1
     _nsec=$(od -An -tu2 -j $((_lfanew + 6)) -N 2 "$_exe" 2>/dev/null | tr -d ' ')
     _szopt=$(od -An -tu2 -j $((_lfanew + 20)) -N 2 "$_exe" 2>/dev/null | tr -d ' ')
     [ -n "$_nsec" ] && [ -n "$_szopt" ] && [ "$_nsec" -gt 0 ] 2>/dev/null || return 1
@@ -267,16 +296,145 @@ title_is_drm_wrapped() {
     # and under a UTF-8 locale macOS grep rejects it as invalid multibyte and
     # matches nothing. Without this the route silently never engages -- and the
     # warning below never fires either, because it asks the same question.
-    dd if="$_exe" bs=1 skip="$_start" count=$((_nsec * 40)) 2>/dev/null \
-        | LC_ALL=C tr -d '\000' | LC_ALL=C grep -q '\.bind'
+    if dd if="$_exe" bs=1 skip="$_start" count=$((_nsec * 40)) 2>/dev/null \
+        | LC_ALL=C tr -d '\000' | LC_ALL=C grep -q '\.bind'; then
+        EXE_WRAPPED=1
+    fi
+    return 0
 }
 
-USE_DRM=0
-if [ "$HAVE_DRM" = 1 ] && shim_drm_enabled && title_is_drm_wrapped "$EXE"; then
-    USE_DRM=1
-elif [ "$HAVE_DRM" = 0 ] && shim_drm_enabled && title_is_drm_wrapped "$EXE"; then
-    log "WARNING: this title is DRM-wrapped and the DRM route is unavailable, so it"
-    log "         will fail with 'Application load error 3:0000065432'."
+# The launcher chain: a REFINEMENT, never the mechanism.
+# A launcher that declares its target does it in a <basename>.ini beside itself
+# with ApplicationPath=. That is a FORMAT rule rather than a per-title one:
+# ADR 0003:206-208 recorded the identical shape on an unrelated title
+# (SpaceMarineBootstrapper.exe -> SpaceMarine.exe, ApplicationPath=,
+# WaitForExit=0) before this issue existed. Following it names the exact binary,
+# which cuts false positives and lets the log say something specific.
+#
+# NOTHING may depend on it. When it does not resolve -- an unknown launcher, an
+# ini the user has edited, a chain that goes through an anti-cheat stub instead
+# -- the sweep below still gives the right answer, so an unfamiliar launcher
+# costs precision, not function. Exercised both ways on Space Marine II: with
+# its ini pointing at the wrapped binary the chain names it exactly, and with
+# the ini pointing at the anti-cheat stub instead the sweep still arms.
+#
+# Hops are capped: an ini naming itself, or a pair naming each other, is a loop,
+# and this runs before the user has seen anything at all.
+DRM_CHAIN_HOPS=4
+drm_chain_next() {
+    _from="$1" _ini= _val=
+    _ini="${_from%.*}.ini"
+    [ -f "$_ini" ] || return 1
+    # key=value, CRLF, no section header. Neither the case of the key nor the
+    # spacing around the = is guaranteed by anything, so do not assume either.
+    # LC_ALL=C for the same reason as above: an ini beside a game EXE is not
+    # promised to be valid UTF-8, and a sed that rejects it matches nothing.
+    _val=$(LC_ALL=C sed -n 's/^[Aa]pplication[Pp]ath[[:space:]]*=[[:space:]]*//p' "$_ini" 2>/dev/null \
+            | head -n 1 | tr -d '\r' | LC_ALL=C sed 's/[[:space:]]*$//')
+    [ -n "$_val" ] || return 1
+    # Windows separators, and relative to the ini's own directory.
+    _val=$(printf '%s' "$_val" | tr '\\' '/')
+    case "$_val" in
+        /*) : ;;
+        *)  _val="$(dirname "$_from")/$_val" ;;
+    esac
+    [ -f "$_val" ] || return 1
+    printf '%s' "$_val"
+}
+
+# The sweep, which is the arming signal.
+# Launcher-agnostic (any matryoshka depth, any convention, including shapes
+# nobody has seen) and packer-agnostic: it asks about Steam's own published
+# format, the same fact ADR 0014 already stakes the route on.
+#
+# Capped on BOTH count and depth, because each EXE costs a few process spawns in
+# POSIX shell and a title shipping hundreds of them would make this expensive.
+# Measured on Space Marine II: 8 EXEs, ~320 bytes of section table each, 150 ms
+# wall for find plus all eight -- and ~2.7 ms per EXE on a 300-file fixture, so
+# the count cap is about 0.7 s of worst case, once, before a launch that is
+# already starting a Wine. When a cap bites we SAY SO at the call site rather
+# than silently answering "no" -- an unfinished sweep is uncertainty, and the
+# branch that tells the user we cannot help must be reachable from there too.
+DRM_SWEEP_MAX_FILES=256
+DRM_SWEEP_MAX_DEPTH=8
+DRM_SWEEP_CAPPED=0
+
+# Sets DRM_WRAPPED_EXE / DRM_WRAPPED_MACHINE / DRM_WRAPPED_HOW when the title
+# ships a wrapped binary, and DRM_SWEEP_CAPPED when it ran out of budget before
+# it could answer. Globals rather than stdout: a command substitution is a
+# subshell, and the "I could not finish" flag has to survive.
+DRM_WRAPPED_EXE=
+DRM_WRAPPED_MACHINE=
+DRM_WRAPPED_HOW=
+drm_locate_wrapped() {
+    _root="$1" _cand= _prev= _hop=0 _n=0 _list= _f=
+    DRM_WRAPPED_EXE=
+    DRM_WRAPPED_MACHINE=
+    DRM_WRAPPED_HOW=
+    DRM_SWEEP_CAPPED=0
+
+    # First the binary Steam named, then whatever it declares. Both are exact,
+    # both are two files' worth of work, and between them they answer for every
+    # title shape we understand -- the sweep is what covers the rest.
+    _cand="$EXE"
+    while [ -n "$_cand" ]; do
+        if exe_read_pe "$_cand" && [ "$EXE_WRAPPED" = 1 ]; then
+            DRM_WRAPPED_EXE="$_cand"
+            DRM_WRAPPED_MACHINE="$EXE_MACHINE"
+            if [ "$_hop" = 0 ]; then
+                DRM_WRAPPED_HOW="the binary Steam handed us"
+            else
+                DRM_WRAPPED_HOW="named by $(basename "${_prev%.*}.ini") (ApplicationPath=)"
+            fi
+            return 0
+        fi
+        [ "$_hop" -lt "$DRM_CHAIN_HOPS" ] || break
+        _prev="$_cand"
+        _cand=$(drm_chain_next "$_cand") || _cand=
+        _hop=$((_hop + 1))
+    done
+
+    # Then every EXE the title ships, scoped to its INSTALL dir -- not to
+    # wherever $EXE happens to live, which for a launcher one directory down is
+    # a subtree that does not contain the game.
+    _list=$(find "$_root" -maxdepth "$DRM_SWEEP_MAX_DEPTH" -type f -iname '*.exe' 2>/dev/null) || true
+    if [ -n "$_list" ]; then
+        while IFS= read -r _f; do
+            [ -n "$_f" ] || continue
+            if [ "$_n" -ge "$DRM_SWEEP_MAX_FILES" ]; then
+                DRM_SWEEP_CAPPED=1
+                break
+            fi
+            _n=$((_n + 1))
+            [ "$_f" = "$EXE" ] && continue
+            if exe_read_pe "$_f" && [ "$EXE_WRAPPED" = 1 ]; then
+                DRM_WRAPPED_EXE="$_f"
+                DRM_WRAPPED_MACHINE="$EXE_MACHINE"
+                DRM_WRAPPED_HOW="found by sweeping the title's EXEs ($_n read)"
+                return 0
+            fi
+        done <<EOF
+$_list
+EOF
+    fi
+
+    # A "no" from a sweep that stopped at the depth cap is not a no. Directories
+    # sitting exactly AT the cap mean there are files below it we never read, so
+    # ask -- one extra find, only on the path where the answer was negative.
+    if [ "$DRM_SWEEP_CAPPED" = 0 ] \
+       && [ -n "$(find "$_root" -mindepth "$DRM_SWEEP_MAX_DEPTH" -maxdepth "$DRM_SWEEP_MAX_DEPTH" \
+                       -type d 2>/dev/null | head -n 1)" ]; then
+        DRM_SWEEP_CAPPED=1
+    fi
+    return 1
+}
+
+# What a user should do about a route that cannot run. Said from TWO places now
+# (#104): the title we know is wrapped, and the title we could not finish
+# checking. It used to be reachable only from the first, which meant a title we
+# failed to recognise got no diagnostic at all -- the user saw Valve's dialog
+# and a launch log that mentioned DRM nowhere. That was the worse half of #104.
+drm_route_unavailable() {
     if [ "$DRM_UNFETCHED" = 1 ]; then
         # Beside us in the deployed payload; in the dev tree it is its module's.
         _fetch="$HERE/$SHIM_PATH_FETCH_SH"
@@ -286,6 +444,61 @@ elif [ "$HAVE_DRM" = 0 ] && shim_drm_enabled && title_is_drm_wrapped "$EXE"; the
     fi
     [ -n "$DRM_MISSING" ] && \
         log "         missing from the payload:$DRM_MISSING — reinstall"
+    # Explicit, and load-bearing under `set -e`: this is called as the last
+    # command of an if-branch, and set -e is NOT ignored there the way it is in
+    # the condition. Falling out of the function on that failing `[` would take
+    # the whole launch down at the point where we were only trying to explain
+    # ourselves -- the diagnostic killing the launch it was diagnosing.
+    return 0
+}
+
+# The scope for the sweep: the TITLE's install directory, which is Valve's to
+# tell us -- STEAM_COMPAT_INSTALL_PATH, from the same contract that carries the
+# app id -- rather than the directory $EXE happens to sit in. They are the same
+# place for a title Steam launches from its root, and they are not for one it
+# does not; assuming the second is a milder version of the bug this fixes.
+TITLEDIR="${STEAM_COMPAT_INSTALL_PATH:-}"
+if [ -z "$TITLEDIR" ] || [ ! -d "$TITLEDIR" ]; then
+    TITLEDIR="$(dirname "$EXE")"
+fi
+
+USE_DRM=0
+if shim_drm_enabled; then
+    drm_locate_wrapped "$TITLEDIR" || true
+fi
+
+# Over-arming has a real cost: this route and the overlay injector are mutually
+# exclusive (ADR 0003, ADR 0014), so a false positive silently costs a working
+# title its overlay. State the finding and how it was reached, every time, so
+# that cost is visible in the log rather than inferred from a missing overlay.
+if [ -n "$DRM_WRAPPED_EXE" ]; then
+    log "DRM: this title is wrapped — $DRM_WRAPPED_EXE"
+    log "     carries Steam's .bind section; $DRM_WRAPPED_HOW"
+fi
+
+if [ -n "$DRM_WRAPPED_EXE" ] && [ "$DRM_WRAPPED_MACHINE" != "$PE_MACHINE_AMD64" ]; then
+    # Sayable at all only because the bitness gate moved out of the predicate.
+    log "WARNING: this title is DRM-wrapped, but the wrapped binary is machine"
+    log "         0x$(printf '%04x' "$DRM_WRAPPED_MACHINE") and the DRM route is 64-bit only (ADR 0014), so it"
+    log "         will fail with 'Application load error 3:0000065432'."
+elif [ -n "$DRM_WRAPPED_EXE" ] && [ "$HAVE_DRM" = 1 ]; then
+    USE_DRM=1
+elif [ -n "$DRM_WRAPPED_EXE" ]; then
+    log "WARNING: this title is DRM-wrapped and the DRM route is unavailable, so it"
+    log "         will fail with 'Application load error 3:0000065432'."
+    drm_route_unavailable
+elif [ "$DRM_SWEEP_CAPPED" = 1 ]; then
+    log "NOTE: could not finish checking whether this title is DRM-wrapped — the"
+    log "      sweep of $TITLEDIR stopped at its cap"
+    log "      ($DRM_SWEEP_MAX_FILES EXEs, $DRM_SWEEP_MAX_DEPTH directories deep). Treat 'not wrapped' as unknown here."
+    if [ "$HAVE_DRM" = 1 ]; then
+        log "      If it fails with 'Application load error 3:0000065432' it IS wrapped and"
+        log "      the sweep missed it — that is worth reporting (#104)."
+    else
+        log "      If it fails with 'Application load error 3:0000065432' it IS wrapped, and"
+        log "      the DRM route is unavailable:"
+        drm_route_unavailable
+    fi
 fi
 
 if [ "$USE_DRM" = 1 ]; then


### PR DESCRIPTION
## What this fixes

`title_is_drm_wrapped "$EXE"` asked whether the file Steam hands the compat tool carries a `.bind` section. For Warhammer 40,000: Space Marine II it does not — that file is a 32-bit outer launcher — so the DRM route never armed through the Play button, and neither did the warning, because both were gated on the same predicate.

Measured on the installed title (`/usr/bin/grep`, and a Python PE parser as a second opinion): **two** of its eight EXEs are wrapped, not one as #104 says —

| binary | machine | `.bind` |
|---|---|---|
| `Warhammer 40000 Space Marine 2.exe` (what Steam launches) | 0x14c | no |
| `start_protected_game.exe` | 0x8664 | no |
| `client_pc/root/bin/pc/… - Retail.exe` | 0x8664 | **yes** |
| `client_pc/root/bin/pc/EpicOnlineServices/start_epic_crossplay_game.exe` | 0x8664 | **yes** |
| the other four | mixed | no |

Both wrapped ones are 64-bit, so the arming decision is the same either way; it only changes which path the log names when the sweep is what fires.

## The design (per #104, all three parts)

**1. A generic sweep is the arming signal.** "Does this title ship a wrapped binary" instead of "is the file Steam named wrapped". Scoped to `STEAM_COMPAT_INSTALL_PATH` (falling back to `dirname $EXE`), capped at 256 EXEs and 8 directories deep. Launcher- and packer-agnostic: it asks about Steam's own published format, the same fact ADR 0014 already stakes the route on. When a cap bites, the log says the answer is *unknown* rather than "not wrapped" — including the depth cap, which is detected by asking whether any directory sits at the limit.

**2. Chain-following is a refinement, never the mechanism.** The `<basename>.ini` / `ApplicationPath=` shape (ADR 0003:206-208 recorded it on an unrelated title) is followed first, up to 4 hops, so the log can name the exact binary. Nothing depends on it: with the ini pointing at the anti-cheat stub, the sweep still arms.

**3. The two questions are split.** `exe_read_pe` is now a pure fact about bytes — it sets `EXE_MACHINE` and `EXE_WRAPPED` in one pass over the headers (each `od`/`dd` is a process spawn and the sweep asks this per EXE). The 64-bit gate moved to the call site, so "wrapped, but we cannot help it" is a branch that exists and logs. The unavailable-route advice is now a function called from **two** places: the title we know is wrapped, and the title we could not finish checking — that is the un-shared gate.

`LC_ALL=C` is kept on the section-table scan, with its comment, and applied to the new ini parsing for the same reason.

## Also fixed while in there

`drm_route_unavailable` (the pre-existing advice block) ends in `[ -n "$DRM_MISSING" ] && log …`. As the last command of an `if` branch under `set -e`, a failing `[` there exits the script — the diagnostic killing the launch it was diagnosing. It now `return 0`s explicitly, with a comment saying why.

## Verified

Detection was exercised by extracting the block verbatim into a harness with `log`/`shim_drm_enabled` stubbed, then:

- **SM2, ini as it is on this machine (points at the retail EXE):** arms, `USE_DRM=1`, via the **chain** — `named by Warhammer 40000 Space Marine 2.ini (ApplicationPath=)`.
- **SM2, ini rewritten to name `start_protected_game.exe` (the stock shape), then restored byte-identical:** arms, `USE_DRM=1`, via the **sweep**.
- **Negative control** — `Steamworks Shared` (VC redists, no `.bind` anywhere): does not arm, and logs nothing at all.
- **32-bit wrapped**: synthetic fixture (retail EXE with `Machine` patched to 0x14c) → does not arm, logs the new `machine 0x014c and the DRM route is 64-bit only` warning.
- **Both caps**: a 301-EXE fixture and a 10-deep tree → `CAPPED=1` and the "could not finish checking" NOTE, in both the route-available and route-unavailable wordings.
- **`SHIM_DRM=0`**: no sweep, no output.
- Cost: 150 ms wall for SM2's 8 EXEs including `find`; ~2.7 ms/EXE on the 300-file fixture, so the cap is ~0.7 s worst case.
- `sh -n`, `./src/installer/build.sh` (every gate: layout drift, policy agreement, shim checkers, shadows, launcher) and `deploy.sh --dry-run` all pass.

**Not verified:** the actual launch through Steam's Play button — I cannot drive the GUI. The route arming, the registry value it selects and the overlay interlock below it are unchanged code paths; what I changed is which binary the predicate is asked about, and that is what the harness covers. Someone with the GUI should confirm 2183900 starts and that `shim-launch.log` shows the two `DRM:` lines followed by `DRM route:`.

## Overlap with #106

#106 landed while this was being written (`50edde2`, `ee873c1`), so this branch is off the current `main` and already carries `$SHIM_PATH_FETCH_SH` / `$SHIM_PATH_CLIENT_DLL_REL` inside the moved advice block. No `layout.json` or `installer/build.sh` change was needed here, so the only shared file was the launch script and it merged cleanly. Nothing to sequence.

## Scope

No title-specific machinery: no appid list, no title name, no per-title branch. Everything here is deleted by #107 except the split questions and the logging, which #107 says survive as diagnostics. ADR 0014 gets an amendment recording that "only wrapped titles take it" now means "only titles that *ship* a wrapped binary", and what that costs (a title with an unlaunched wrapped EXE loses its overlay).

## Worth a separate issue?

- `start_epic_crossplay_game.exe` being wrapped too means SM2 is a title where the sweep has two right answers. Harmless here; a title where the second wrapped EXE were 32-bit would make the log's chosen binary decide the branch. Probably moot once #107 lands.
- The sweep reports the first wrapped EXE `find` returns, which is directory order, not a ranking. If the log line's precision ever matters more than it does today, preferring the chain target / deepest match would be the fix.

Closes #104.
