### PR TITLE
fix(launcher): a stalled cxbottle or download hung the app with no way back

### DIFF
--- a/src/launcher/AppModel.swift
+++ b/src/launcher/AppModel.swift
@@ -23,6 +23,10 @@ final class AppModel: ObservableObject {
     /// Valve" and the user would press the same button expecting a different
     /// result. This is what the row says instead, until something changes it.
     @Published var valveClientProblem: String?
+    /// The same idea for bottle creation, and for the same reason: the bottle
+    /// row is a `fileExists`, so a `cxbottle` we had to kill leaves the row
+    /// exactly as it was before the button was pressed (#108).
+    @Published var bottleProblem: String?
 
     enum LaunchState: Equatable {
         case idle
@@ -119,7 +123,7 @@ final class AppModel: ObservableObject {
         if mustQuitSteamFirst {
             busy = "Quitting Steam…"
             Task.detached {
-                Shell.run("/usr/bin/osascript", ["-e", "quit app \"Steam\""])
+                Shell.run("/usr/bin/osascript", ["-e", "quit app \"Steam\""], timeout: 20)
                 for _ in 0..<40 where Shell.isRunning(ShimPath.steamOsx) {
                     try? await Task.sleep(nanoseconds: 500_000_000)
                 }
@@ -189,7 +193,15 @@ final class AppModel: ObservableObject {
     }
 
     func createBottle() {
-        perform("Making the bottle…") { Preflight.createBottle().output }
+        busy = "Making the bottle…"
+        Task.detached {
+            let result = Preflight.createBottle()
+            await MainActor.run {
+                self.busy = nil
+                self.bottleProblem = result.timedOut ? Preflight.bottleTimedOut : nil
+                self.refresh()
+            }
+        }
     }
 
     func runDiagnose() {
@@ -220,7 +232,11 @@ final class AppModel: ObservableObject {
 
     func restartSteam() {
         perform("Restarting Steam…") {
-            Shell.run("/usr/bin/osascript", ["-e", "quit app \"Steam\""])
+            // Bounded well under the default: `quit app` blocks for as long as
+            // the app takes to go, and a Steam showing a modal dialog never
+            // does. The poll below already handles a client that is still up,
+            // so 20 seconds of waiting is the whole value of asking politely.
+            Shell.run("/usr/bin/osascript", ["-e", "quit app \"Steam\""], timeout: 20)
             for _ in 0..<30 where Shell.isRunning(ShimPath.steamOsx) {
                 Thread.sleep(forTimeInterval: 0.5)
             }

--- a/src/launcher/Diagnose.swift
+++ b/src/launcher/Diagnose.swift
@@ -34,6 +34,14 @@ enum Diagnose {
             return Finding(id: "integrity", title: "Steam Play is not installed", verdict: .blocked,
                            detail: "Reinstall to put the files in place.")
         }
+        // A verify that never answered is not a verify that failed: saying
+        // "files have gone missing" would send someone to reinstall over a
+        // stalled script (#108).
+        if result.timedOut {
+            return Finding(id: "integrity", title: "The file check did not finish", verdict: .warning,
+                           detail: "Checking the installed files took too long and was stopped. "
+                                 + "Try Diagnose again; if it keeps happening, reinstall.")
+        }
         return Finding(id: "integrity",
                        title: result.ok ? "Files are intact" : "Some files have changed or gone missing",
                        verdict: result.ok ? .ok : .blocked,

--- a/src/launcher/Preflight.swift
+++ b/src/launcher/Preflight.swift
@@ -163,6 +163,10 @@ enum Preflight {
     static var bottleName: String {
         ProcessInfo.processInfo.environment["SHIM_BOTTLE"] ?? ShimPath.bottleDefault
     }
+    /// The id the bottle rows carry, so the pane that showed the "Create it"
+    /// button knows which row a failure belongs in — the same arrangement
+    /// `ValveClient.rowID` has.
+    static let bottleRowID = "bottle"
     static var bottlePath: String {
         ShimPath.inHome(ShimPath.cxBottlesRel) + "/" + bottleName
     }
@@ -170,7 +174,7 @@ enum Preflight {
     static func bottle() -> Check {
         let fm = FileManager.default
         guard fm.fileExists(atPath: bottlePath) else {
-            return Check(id: "bottle", title: "No CrossOver bottle yet",
+            return Check(id: bottleRowID, title: "No CrossOver bottle yet",
                          verdict: .blocked,
                          detail: "Windows games run inside a CrossOver bottle. This app can make one for you.",
                          remedy: .createBottle,
@@ -180,16 +184,28 @@ enum Preflight {
                                "drive_c/Program Files/Steam/steam.exe"]
             .contains { fm.fileExists(atPath: bottlePath + "/" + $0) }
         if hasWindowsSteam {
-            return Check(id: "bottle", title: "The CrossOver bottle has a Windows Steam in it",
+            return Check(id: bottleRowID, title: "The CrossOver bottle has a Windows Steam in it",
                          verdict: .blocked,
                          detail: "There is a Windows copy of Steam in this bottle. Games will talk to that instead of the Steam on your Mac. Delete it, or use a different bottle.")
         }
         // The bottle's name is a setting, not news. It appears where someone can
         // act on it (the uninstall toggle), not in a row whose job is "fine".
-        return Check(id: "bottle", title: "CrossOver bottle configured", verdict: .ok, detail: "")
+        return Check(id: bottleRowID, title: "CrossOver bottle configured", verdict: .ok, detail: "")
     }
 
+    /// What a bottle that never finished says. The row is recomputed from disk
+    /// and there is still no bottle there, so without this the checklist goes
+    /// back to "This app can make one for you" and invites the same button and
+    /// the same five-minute wait (#108).
+    static let bottleTimedOut =
+        "Making the bottle took more than five minutes and was stopped. Open CrossOver "
+        + "once to let it finish setting itself up, then try again."
+
     /// CodeWeavers' own tool, with the flags the README used to have to teach.
+    /// The five minutes is now a bound and not a hope: bottle creation is
+    /// CodeWeavers' code, it touches the network on some paths, and it is
+    /// offered as a button on the checklist — so a stall used to present as an
+    /// app that had stopped responding (#108).
     static func createBottle() -> Shell.Result {
         let cxbottle = crossoverApp + "/Contents/SharedSupport/CrossOver/bin/cxbottle"
         return Shell.run(cxbottle, ["--create", "--bottle", bottleName, "--template", "win10_64"], timeout: 300)

--- a/src/launcher/Shell.swift
+++ b/src/launcher/Shell.swift
@@ -10,13 +10,36 @@ import Foundation
 /// check, and none of that gets a second implementation either), `cxbottle`
 /// (CodeWeavers' bottle creation, whose incantation this app exists to keep out
 /// of the README), and `pgrep`.
+///
+/// Every one of them is somebody else's process, which is why the timeouts here
+/// are real and not decoration: until #108 `run` took a `timeout` and never
+/// referenced it, so `Preflight.createBottle`'s `timeout: 300` bounded nothing
+/// and a stalled `cxbottle` was an app that had stopped responding with no way
+/// back.
 enum Shell {
     struct Result {
         let status: Int32
         let output: String
+        /// We killed it; it did not choose this exit code. A caller has to be
+        /// able to tell the two apart, because "the command said no" and "the
+        /// command never answered" are different sentences to put in front of a
+        /// user. Stored rather than a sentinel status: 124 below is `timeout(1)`'s
+        /// convention and good enough to print, but a child is free to exit 124
+        /// on its own and this flag is not.
+        var timedOut: Bool = false
         var ok: Bool { status == 0 }
     }
 
+    /// What a killed child's status reads as. `timeout(1)`'s number, so a status
+    /// that reaches a log or a Diagnose report is not mistaken for a clean exit.
+    static let timeoutStatus: Int32 = 124
+
+    /// Blocking, on the caller's thread — never the main one.
+    ///
+    /// `timeout` is the whole operation: spawn, output, exit. A child still
+    /// alive at the deadline is killed and reported as `timedOut`, with whatever
+    /// it managed to say kept — a stalled command's last line is usually the
+    /// only clue about where it stalled.
     @discardableResult
     static func run(_ path: String, _ args: [String], timeout: TimeInterval = 120) -> Result {
         guard FileManager.default.isExecutableFile(atPath: path) else {
@@ -33,11 +56,14 @@ enum Shell {
         }
         // Read before waiting: a command that fills the pipe buffer while we
         // wait for it to exit is a deadlock, and `deploy.sh --verify` prints a
-        // line per problem.
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        proc.waitUntilExit()
-        return Result(status: proc.terminationStatus,
-                      output: String(data: data, encoding: .utf8) ?? "")
+        // line per problem. Which is also why the bound cannot be a timer around
+        // `readDataToEndOfFile` — the read has to keep happening while the clock
+        // runs, so the wait IS the read (see `drain`).
+        let deadline = Date().addingTimeInterval(timeout)
+        var data = Data()
+        let finished = drain(pipe.fileHandleForReading, until: deadline, idle: nil) { data.append($0) }
+            && wait(proc, until: deadline)
+        return finish(proc, output: String(data: data, encoding: .utf8) ?? "", finished: finished)
     }
 
     /// The same thing, for a command slow enough that its silence is the
@@ -47,8 +73,16 @@ enum Shell {
     /// step is running rather than "Working…" for a minute (#105).
     ///
     /// Blocking, like `run`, and on the caller's thread — never the main one.
+    ///
+    /// `idleTimeout` is deliberately not the same clock as `run`'s: these are the
+    /// commands with no honest total bound — 60 MB over an unknown line takes as
+    /// long as it takes, and a wall-clock cap would kill a download that was
+    /// working. What is never legitimate is a command that narrates its steps
+    /// going quiet, so the budget is time *between* lines and it resets on every
+    /// one (#108). `fetch.sh`'s `curl --max-time` still holds; this is the bound
+    /// for the day a caller arrives without one of its own.
     @discardableResult
-    static func stream(_ path: String, _ args: [String],
+    static func stream(_ path: String, _ args: [String], idleTimeout: TimeInterval = 120,
                        onLine: @escaping (String) -> Void) -> Result {
         guard FileManager.default.isExecutableFile(atPath: path) else {
             return Result(status: 127, output: "\(path): not executable")
@@ -68,8 +102,7 @@ enum Shell {
         // said last, not by the exit code alone.
         var output = ""
         var pending = ""
-        let handle = pipe.fileHandleForReading
-        while case let chunk = handle.availableData, !chunk.isEmpty {
+        let quiet = drain(pipe.fileHandleForReading, until: .distantFuture, idle: idleTimeout) { chunk in
             let text = String(data: chunk, encoding: .utf8) ?? ""
             output += text
             pending += text
@@ -80,11 +113,104 @@ enum Shell {
             for line in parts.dropLast() where !line.isEmpty { onLine(line) }
         }
         if !pending.isEmpty { onLine(pending) }
-        proc.waitUntilExit()
-        return Result(status: proc.terminationStatus, output: output)
+        // A child that closed its pipe and then hung is still a hang, and the
+        // same silence budget is the right one to give it to finish.
+        let finished = quiet && wait(proc, until: Date().addingTimeInterval(idleTimeout))
+        return finish(proc, output: output, finished: finished)
     }
 
     static func isRunning(_ pattern: String) -> Bool {
         run("/usr/bin/pgrep", ["-f", pattern]).ok
+    }
+
+    // MARK: - the bound
+
+    /// Read a child's pipe until it closes it, or until the clock runs out.
+    ///
+    /// This is the whole trick of #108. Draining and waiting cannot be two
+    /// phases — the read blocks before any wait is reached, and stopping the
+    /// read to watch a clock is the pipe-buffer deadlock the comment in `run`
+    /// warns about. So the clock is inside the read: `poll(2)` sleeps on the
+    /// pipe for exactly what is left of the budget and returns the instant a
+    /// byte arrives, which costs a fast command nothing.
+    ///
+    /// `idle` (`stream`) restarts the budget on every chunk; `nil` (`run`) makes
+    /// `until` a hard wall. Returns false when the clock won.
+    private static func drain(_ handle: FileHandle, until hard: Date, idle: TimeInterval?,
+                              onChunk: (Data) -> Void) -> Bool {
+        let fd = handle.fileDescriptor
+        var quiet = idle.map { Date().addingTimeInterval($0) } ?? .distantFuture
+        var buffer = [UInt8](repeating: 0, count: 65536)
+        while true {
+            let deadline = min(hard, quiet)
+            let left = deadline.timeIntervalSinceNow
+            if left <= 0 { return false }
+            var pfd = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+            // Milliseconds, and capped: `poll` takes an Int32 and a budget of
+            // `.distantFuture` overflows it. An hour is not a bound anyone
+            // relies on — it is just a number that fits, and the loop re-arms.
+            let n = poll(&pfd, 1, Int32(min(left * 1000, 3_600_000).rounded(.up)))
+            if n == 0 { return false }
+            if n < 0 {
+                if errno == EINTR { continue }
+                // Nothing left to read from and no way to ask why. Treat it as
+                // the end of the output rather than as a timeout: the exit
+                // status is still the honest answer.
+                return true
+            }
+            let count = read(fd, &buffer, buffer.count)
+            if count < 0 {
+                if errno == EINTR || errno == EAGAIN { continue }
+                return true
+            }
+            if count == 0 { return true }  // the child closed the pipe
+            onChunk(Data(buffer[0..<count]))
+            if let idle { quiet = Date().addingTimeInterval(idle) }
+        }
+    }
+
+    /// EOF on the pipe is not the same event as exit — a child can close its
+    /// output and keep running — so the wait gets a bound of its own. Polled
+    /// rather than `waitUntilExit`, which is the other unbounded call #108 is
+    /// about. The sleep is short because this loop is on the path of every
+    /// `pgrep`: by the time the pipe is closed the child is already gone, and
+    /// what is being waited on is only `Process` noticing.
+    /// Measured over 20 `/bin/echo` runs: 67 ms a call before this change, 72 ms
+    /// with a 1 ms sleep, 77 ms with a 5 ms one — so the sleep is the granularity
+    /// of the whole change, against the ~67 ms `Process` spends spawning anything
+    /// at all.
+    private static func wait(_ proc: Process, until deadline: Date) -> Bool {
+        while proc.isRunning {
+            if Date() >= deadline { return false }
+            Thread.sleep(forTimeInterval: 0.001)
+        }
+        proc.waitUntilExit()
+        return true
+    }
+
+    /// Common ending: a child that ran out of clock is killed here rather than
+    /// left behind. Orphaning it is not a fix — a runaway `cxbottle` still holds
+    /// the bottle it was half-way through creating, and a runaway `curl` still
+    /// spends the user's 60 MB.
+    private static func finish(_ proc: Process, output: String, finished: Bool) -> Result {
+        guard !finished else {
+            return Result(status: proc.terminationStatus, output: output)
+        }
+        stop(proc)
+        return Result(status: timeoutStatus, output: output, timedOut: true)
+    }
+
+    /// SIGTERM, then SIGKILL for whatever ignores it. Only the direct child:
+    /// `Process` does not give it a process group of its own, so it shares ours
+    /// and killing the group would kill the launcher. A shell wrapper that
+    /// spawned helpers can therefore leave some behind — everything we run
+    /// either is the work (`cxbottle`, `pgrep`, `osascript`) or is a script
+    /// whose helpers die with the pipe.
+    private static func stop(_ proc: Process) {
+        guard proc.isRunning else { proc.waitUntilExit(); return }
+        proc.terminate()
+        if wait(proc, until: Date().addingTimeInterval(2)) { return }
+        kill(proc.processIdentifier, SIGKILL)
+        _ = wait(proc, until: Date().addingTimeInterval(2))
     }
 }

--- a/src/launcher/UI.swift
+++ b/src/launcher/UI.swift
@@ -191,12 +191,18 @@ struct RemedyButton: View {
     }
 }
 
-/// What a row says, once the model knows better than the row does. Only the
-/// DRM download has anything to add: its check is a stat, so after a failed
-/// fetch the file is still missing and the row would go back to explaining why
-/// it is needed — while what the user needs to read is why it did not arrive.
+/// What a row says, once the model knows better than the row does. Two rows
+/// have anything to add, and for one reason: their checks are stat calls, so
+/// after a remedy that did not work the file is still missing and the row goes
+/// back to explaining why it is needed — while what the user needs to read is
+/// why it did not arrive (the DRM download) or why it did not finish (the
+/// bottle, #108).
 @MainActor private func rowDetail(_ id: String, _ detail: String, _ model: AppModel) -> String {
-    id == ValveClient.rowID ? (model.valveClientProblem ?? detail) : detail
+    switch id {
+    case ValveClient.rowID: return model.valveClientProblem ?? detail
+    case Preflight.bottleRowID: return model.bottleProblem ?? detail
+    default: return detail
+    }
 }
 
 // MARK: - checklist (first run, or preflight broken)

--- a/src/launcher/ValveClient.swift
+++ b/src/launcher/ValveClient.swift
@@ -64,7 +64,13 @@ enum ValveClient {
         // timestamp gates is the UNATTENDED retry, so a failure has to count.
         Prefs.lastClientFetch = Date()
         var last = ""
-        let result = Shell.stream(fetcher, []) { line in
+        // Longer than `fetch.sh`'s own `curl --max-time 900`, on purpose: the
+        // script owns the bound on the download (it is the half that knows the
+        // endpoint), and a launcher bound that fired first would kill a fetch
+        // that was still within its own budget. This is the backstop for the
+        // case the script cannot cover — a curl that is neither transferring
+        // nor timing out — and for a future caller that brings no bound (#108).
+        let result = Shell.stream(fetcher, [], idleTimeout: 960) { line in
             // Its own narration only. `drm-fetch:` is a prefix for a log, not
             // for a label under a spinner — and the lines WITHOUT it come from
             // the shadow coverage checker it calls, which reports in full paths
@@ -77,6 +83,11 @@ enum ValveClient {
             progress(text)
         }
         if result.ok { return .ok }
+        if result.timedOut {
+            return .failed("The download stopped responding and was cancelled. Try again — "
+                         + "everything else works without this; only copy-protected games "
+                         + "need it.")
+        }
         return .failed(explain(result.status, last: last))
     }
 


### PR DESCRIPTION
`Shell.run` took a `timeout` and never referenced it. Both of its blocking calls
were unbounded — `readDataToEndOfFile()` returns when the child closes the pipe,
`waitUntilExit()` when it exits — and `Shell.stream` (#106) inherited the gap
without even a parameter to discard.

Closes #108.

## Apply the bound, not delete it

The issue offers both. Applied, because of what the eight call sites actually
are: two of them are other people's long-running code (`cxbottle --create`, the
60 MB `fetch.sh`), both are offered to the user as a button on a checklist, and
one of them — `osascript -e 'quit app "Steam"'` — can genuinely block forever
when Steam is showing a modal dialog. Deleting the parameter would have made
"this can hang the app with no way back" honest and left it true. The prime rule
(ADR 0011) is that the app is invisible when it works; the visible failure mode
of an unbounded wait is a spinner that never stops, which is the worst UI this
app can show.

No call site is left believing in a bound that does not exist:

| call site | bound | why |
|---|---|---|
| `Preflight.createBottle` | `timeout: 300` (unchanged) | the number that was already written down, now enforced |
| `AppModel` × 2, `osascript quit` | `timeout: 20` | AppleScript waits on an app that may never go; the `isRunning` poll after it already covers a client still up |
| `Diagnose` `deploy.sh --verify`, `LogWatch` `ps`/`pgrep`, `isRunning` | default 120 s | local file work and process queries; the default is a backstop they will never reach |
| `ValveClient` `Shell.stream(fetcher)` | `idleTimeout: 960` | see below |

## The two traps

**You cannot time out `readDataToEndOfFile()`.** It blocks before `waitUntilExit()`
is ever reached, and the read-before-wait ordering is load-bearing against a
pipe-buffer deadlock (`deploy.sh --verify` prints a line per problem). Stopping
the read to watch a clock reintroduces exactly that deadlock. So the clock went
*inside* the read: `poll(2)` on the pipe fd for whatever is left of the budget,
in a loop that drains as it goes. It returns the instant a byte arrives, so a
fast command pays no polling latency, and a child that fills the buffer is being
drained the whole time. EOF is then followed by a second, also-bounded wait,
because a child can close its output and keep running — that is the other
unbounded call.

**A timed-out child is killed, not orphaned.** `proc.terminate()` (SIGTERM), a
2 s grace, then `kill(pid, SIGKILL)`. Only the direct child: `Process` does not
give it a process group of its own, so it shares ours and killing the group
would kill the launcher — noted in the source.

`stream` is a different problem and got a different bound. A 60 MB download over
an unknown line has no honest wall-clock cap; one would kill a fetch that was
working. What is never legitimate is a command that narrates its steps going
quiet, so `stream`'s budget is time *between* lines and resets on every one.
`fetch.sh`'s own `curl --max-time 900` stays the authoritative bound on the
download; the launcher's 960 s is the backstop for a curl that is neither
transferring nor timing out, and for the next caller that brings no bound.

## Telling a timeout from a refusal

`Result.timedOut`, stored, with `status` set to 124 (`timeout(1)`'s convention)
so a status that reaches a log is not mistaken for a clean exit. Stored rather
than a sentinel alone: a child is free to exit 124 on its own; the flag is not.
Call sites already read `.ok`/`.status`, and the memberwise `Result(status:output:)`
initialiser is unchanged, so nothing else moved.

ADR 0011 says a timeout firing is a real failure and must produce something a
user can act on. Three places needed it:

- **The bottle row.** `perform` discarded the output, and the row is a
  `fileExists` — so a killed `cxbottle` left the checklist saying "This app can
  make one for you", inviting the same button and the same five-minute wait. It
  now says what happened, through the same `rowDetail` hook `valveClientProblem`
  already used (generalised to two rows).
- **Diagnose's integrity row.** A verify that never answered is not a verify
  that failed; "files have gone missing" would send someone to reinstall over a
  stalled script.
- **The DRM fetch**, which already had a failure sentence per exit code and now
  has one for silence.

## Test results (observed, on this machine)

A throwaway harness compiled against the real `Shell.swift` (kept out of the
repo). Times are wall clock; `pgrep` was run one second after each timeout.

```
(a) run /bin/sleep 30, timeout 2   2.07s  status=124 timedOut=YES   pgrep after: []
(b) run 200 KB then exit 7         0.25s  status=7   timedOut=no    200001 bytes, all of it
(c) two lines then sleep 600, t=3  3.07s  status=124 timedOut=YES   output "hello\nworld\n"; pgrep after: []
(c2) never writes at all, t=2      2.07s  status=124 timedOut=YES   pgrep after: []
(d) run /bin/echo hi               0.07s  status=0   timedOut=no    "hi\n"
    run /usr/bin/false             0.07s  status=1   timedOut=no
    run /nope/nothing              0.00s  status=127 timedOut=no    unchanged 127 path
stream 200 KB                      0.10s  status=7   timedOut=no    200001 bytes
stream 3 lines 1s apart, idle 2s   3.26s  status=0   timedOut=no    all three lines — idle budget resets
stream two lines then silent, idle 2s     status=124 timedOut=YES   both lines kept; pgrep after: []
off the main thread (global queue)  1.07s status=124 timedOut=YES
traps SIGTERM, timeout 2           4.07s  status=124 timedOut=YES   SIGKILL after the 2s grace; pgrep after: []
```

Cost, 20 runs each: `/bin/echo` 67 ms a call before this change, 72 ms after;
`pgrep -f` 83 ms before, 89 ms after — against the ~67 ms `Process` spends
spawning anything at all. A 1 ms exit-poll measured better than 5 ms (72 vs
77 ms), which is why it is 1 ms.

Gates: `src/launcher/build.sh` (including `check_launch_env.sh` — DYLD merge,
overlay, wildcard mapping: all ok), the full `src/installer/build.sh` (layout
drift, both policy predicates, all four shim checkers, DRM shadow coverage,
both bitnesses, payload staged), and `deploy.sh --dry-run`. All pass.

## Changelog

User-visible, so the commit carries a `Changelog:` footer: the two remedies a
user actually presses — create the bottle, download Valve's file — could hang
the app until it was force-quit, and now stop and explain themselves.

## Note on #104

Touches `src/launcher/` only (`Shell`, `Preflight`, `AppModel`, `UI`,
`Diagnose`, `ValveClient`). Nothing in `src/compat-tool/`, `src/layout/` or
`src/installer/` — no overlap with the concurrent #104 work.
